### PR TITLE
Fix issues #3, #10, and #11 (not #9, as the commit message says)

### DIFF
--- a/XmlResolver/SampleApp/Program.cs
+++ b/XmlResolver/SampleApp/Program.cs
@@ -15,7 +15,7 @@ namespace SampleApp {
             XmlResolverConfiguration config = new XmlResolverConfiguration();
             // The SampleApp refers to the XmlResolverData NuGet, so I can assume all of
             // the common resources in that assembly will be available.
-            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOG, "XmlResolverData.dll");
+            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, "XmlResolverData.dll");
 
             string document = null;
             

--- a/XmlResolver/UnitTests/FeatureTest.cs
+++ b/XmlResolver/UnitTests/FeatureTest.cs
@@ -1,0 +1,208 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Org.XmlResolver;
+using Org.XmlResolver.Cache;
+using Org.XmlResolver.Features;
+
+namespace UnitTests {
+    public class FeatureTest {
+        private XmlResolverConfiguration config;
+
+        [SetUp]
+        public void Setup() {
+            config = new XmlResolverConfiguration();
+        }
+        
+        private void BooleanFeature(BoolResolverFeature feature) {
+            bool orig = (bool) config.GetFeature(feature);
+            config.SetFeature(feature, false);
+            Assert.AreEqual(false, config.GetFeature(feature));
+            config.SetFeature(feature, true);
+            Assert.AreEqual(true, config.GetFeature(feature));
+            config.SetFeature(feature, orig);
+        }
+
+        private void StringFeature(StringResolverFeature feature) {
+            string orig = (string) config.GetFeature(feature);
+            config.SetFeature(feature, "apple pie");
+            Assert.AreEqual("apple pie", config.GetFeature(feature));
+            config.SetFeature(feature, orig);
+        }
+
+        [Test]
+        public void TestAllowCatalogPi() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.ALLOW_CATALOG_PI));
+            BooleanFeature(ResolverFeature.ALLOW_CATALOG_PI);
+        }
+        
+        [Test]
+        public void TestArchivedCatalogs() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.ARCHIVED_CATALOGS));
+            BooleanFeature(ResolverFeature.ARCHIVED_CATALOGS);
+        }
+
+        [Test]
+        public void TestCacheUnderHome() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.CACHE_UNDER_HOME));
+            BooleanFeature(ResolverFeature.CACHE_UNDER_HOME);
+        }
+
+        [Test]
+        public void TestMaskPackUris() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.MASK_PACK_URIS));
+            BooleanFeature(ResolverFeature.MASK_PACK_URIS);
+        }
+
+        [Test]
+        public void TestMergeHttps() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.MERGE_HTTPS));
+            BooleanFeature(ResolverFeature.MERGE_HTTPS);
+        }
+
+        [Test]
+        public void TestParseRddl() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.PARSE_RDDL));
+            BooleanFeature(ResolverFeature.PARSE_RDDL);
+        }
+
+        [Test]
+        public void TestPreferPropertyFile() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.PREFER_PROPERTY_FILE));
+            BooleanFeature(ResolverFeature.PREFER_PROPERTY_FILE);
+        }
+
+        [Test]
+        public void TestPreferPublic() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.PREFER_PUBLIC));
+            BooleanFeature(ResolverFeature.PREFER_PUBLIC);
+        }
+
+        [Test]
+        public void TestUriForSystem() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.URI_FOR_SYSTEM));
+            BooleanFeature(ResolverFeature.URI_FOR_SYSTEM);
+        }
+
+        [Test]
+        public void TestAssemblyCatalog() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.ASSEMBLY_CATALOGS));
+            
+            List<string> orig = (List<string>)config.GetFeature(ResolverFeature.ASSEMBLY_CATALOGS);
+            
+            List<string> myCatalogs = new List<string> { "One", "Two", "Three" };
+            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, myCatalogs);
+            List<string> current = (List<string>)config.GetFeature(ResolverFeature.ASSEMBLY_CATALOGS);
+            sameLists(current, myCatalogs);
+
+            myCatalogs = new List<string> { "Alpha", "Beta", "Gamma" };
+            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, myCatalogs);
+            current = (List<string>)config.GetFeature(ResolverFeature.ASSEMBLY_CATALOGS);
+            sameLists(current, myCatalogs);
+
+            // For backwards compatibility, this feature accepts either a string or a list of strings
+            // If you provide a single string, it adds that string to the list.
+
+            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, "Spoon");
+            myCatalogs = new List<string> { "Alpha", "Beta", "Gamma", "Spoon" };
+            current = (List<string>)config.GetFeature(ResolverFeature.ASSEMBLY_CATALOGS);
+            sameLists(current, myCatalogs);
+
+            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, orig);
+        }
+
+        [Test]
+        public void TestCacheDirectory() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.CACHE_DIRECTORY));
+            StringFeature(ResolverFeature.CACHE_DIRECTORY);
+        }
+
+        [Test]
+        public void TestCatalogLoaderClass() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.CATALOG_LOADER_CLASS));
+            StringFeature(ResolverFeature.CATALOG_LOADER_CLASS);
+        }
+
+        private void sameLists(List<string> list1, List<string> list2) {
+            // Hack
+            foreach (var cur in list1) {
+                Assert.True(list2.Contains(cur));
+            }
+            foreach (var cur in list2) {
+                Assert.True(list1.Contains(cur));
+            }
+        }
+
+        [Test]
+        public void TestFeatureCatalogFiles() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.CATALOG_FILES));
+
+            List<string> orig = (List<string>)config.GetFeature(ResolverFeature.CATALOG_FILES);
+            List<string> myList = new List<string> { "One", "Two", "Three" };
+            config.SetFeature(ResolverFeature.CATALOG_FILES, myList);
+            List<string> current = (List<string>)config.GetFeature(ResolverFeature.CATALOG_FILES);
+            sameLists(current, myList);
+
+            // Setting CATALOG_FILES replaces the list
+            List<string> newList = new List<string> { "Alpha", "Beta", "Gamma" };
+            config.SetFeature(ResolverFeature.CATALOG_FILES, newList);
+            current = (List<string>)config.GetFeature(ResolverFeature.CATALOG_FILES);
+
+            // None of "mine" survived
+            foreach (var cur in myList) {
+                Assert.False(current.Contains(cur));
+            }
+            
+            sameLists(current, newList);
+            
+            config.SetFeature(ResolverFeature.CATALOG_FILES, orig);
+        }
+        
+        [Test]
+        public void TestFeatureCatalogAdditions() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.CATALOG_ADDITIONS));
+
+            List<string> origCatalogs = (List<string>)config.GetFeature(ResolverFeature.CATALOG_FILES);
+            List<string> origAdditions = (List<string>)config.GetFeature(ResolverFeature.CATALOG_ADDITIONS);
+            
+            List<string> myCatalogs = new List<string> { "One", "Two", "Three" };
+            config.SetFeature(ResolverFeature.CATALOG_FILES, myCatalogs);
+            List<string> current = (List<string>)config.GetFeature(ResolverFeature.CATALOG_FILES);
+            sameLists(current, myCatalogs);
+            
+            // Setting CATALOG_ADDITIONS augments the list of catalogs
+            List<string> myList = new List<string> { "Alpha", "Beta", "Gamma" };
+            config.SetFeature(ResolverFeature.CATALOG_ADDITIONS, myList);
+            current = (List<string>)config.GetFeature(ResolverFeature.CATALOG_FILES);
+
+            foreach (var mine in myCatalogs) {
+                Assert.True(current.Contains(mine));
+            }
+            foreach (var mine in myList) {
+                Assert.True(current.Contains(mine));
+            }
+
+            config.SetFeature(ResolverFeature.CATALOG_FILES, origCatalogs);
+            config.SetFeature(ResolverFeature.CATALOG_ADDITIONS, origAdditions);
+        }
+
+        [Test]
+        public void TestFeatureCatalogManager() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.CATALOG_MANAGER));
+            CatalogManager manager = new CatalogManager(config);
+            CatalogManager orig = (CatalogManager)config.GetFeature(ResolverFeature.CATALOG_MANAGER);
+            config.SetFeature(ResolverFeature.CATALOG_MANAGER, manager);
+            Assert.AreSame(manager, config.GetFeature(ResolverFeature.CATALOG_MANAGER));
+            config.SetFeature(ResolverFeature.CATALOG_MANAGER, orig);
+        }
+
+        [Test]
+        public void TestFeatureCache() {
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.CACHE));
+            ResourceCache myCache = new ResourceCache(config);
+            ResourceCache orig = (ResourceCache)config.GetFeature(ResolverFeature.CACHE);
+            config.SetFeature(ResolverFeature.CACHE, myCache);
+            Assert.AreSame(myCache, config.GetFeature(ResolverFeature.CACHE));
+            config.SetFeature(ResolverFeature.CACHE, orig);
+        }
+    }
+}

--- a/XmlResolver/UnitTests/ResolverTestJar.cs
+++ b/XmlResolver/UnitTests/ResolverTestJar.cs
@@ -17,7 +17,7 @@ namespace UnitTests {
             config.SetFeature(ResolverFeature.URI_FOR_SYSTEM, true);
             config.SetFeature(ResolverFeature.CACHE, null);
             config.SetFeature(ResolverFeature.CACHE_UNDER_HOME, false);
-            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOG, "UnitTests.dll");
+            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, "UnitTests.dll");
             resolver = new Resolver(config);
         }
         

--- a/XmlResolver/XmlResolver/Org/XmlResolver/CatalogManager.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/CatalogManager.cs
@@ -12,7 +12,7 @@ namespace Org.XmlResolver {
     public class CatalogManager : IXmlCatalogResolver {
         protected static ResolverLogger logger = new(LogManager.GetCurrentClassLogger());
         protected readonly ResolverConfiguration _resolverConfiguration;
-        protected CatalogLoader _catalogLoader;
+        protected ICatalogLoader _catalogLoader;
 
         public CatalogManager(ResolverConfiguration config) {
             _resolverConfiguration = config;
@@ -22,7 +22,12 @@ namespace Org.XmlResolver {
             }
 
             // FIXME: what if this doesn't work?
-            _catalogLoader = (CatalogLoader) Activator.CreateInstance(Type.GetType(loaderClassName));
+            _catalogLoader = (ICatalogLoader) Activator.CreateInstance(Type.GetType(loaderClassName));
+            if (_catalogLoader == null) {
+                throw new NullReferenceException("Failed to create catalog loader from " + loaderClassName);
+            }
+            _catalogLoader.SetPreferPublic((bool) config.GetFeature(ResolverFeature.PREFER_PUBLIC));
+            _catalogLoader.SetArchivedCatalogs((bool) config.GetFeature(ResolverFeature.ARCHIVED_CATALOGS));
         }
 
         public CatalogManager(CatalogManager current, ResolverConfiguration config) {

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Features/ResolverFeature.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Features/ResolverFeature.cs
@@ -95,8 +95,8 @@ namespace Org.XmlResolver.Features {
         public static readonly BoolResolverFeature PARSE_RDDL = register(new BoolResolverFeature(
             "http://xmlresolver.org/feature/parse-rddl", true));
 
-        public static readonly StringResolverFeature ASSEMBLY_CATALOG = register(new StringResolverFeature(
-            "http://xmlresolver.org/feature/assembly-catalog", null));
+        public static readonly ListOfStringResolverFeature ASSEMBLY_CATALOGS = register(new ListOfStringResolverFeature(
+            "http://xmlresolver.org/feature/assembly-catalog", new List<string> ()));
 
         public static readonly BoolResolverFeature ARCHIVED_CATALOGS = register(new BoolResolverFeature(
             "http://xmlresolver.org/feature/archived-catalogs", true));

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Loaders/ICatalogLoader.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Loaders/ICatalogLoader.cs
@@ -3,10 +3,12 @@ using System.IO;
 using Org.XmlResolver.Catalog.Entry;
 
 namespace Org.XmlResolver.Loaders {
-    public interface CatalogLoader {
+    public interface ICatalogLoader {
         public EntryCatalog LoadCatalog(Uri caturi);
         public EntryCatalog LoadCatalog(Uri caturi, Stream data);
         public void SetPreferPublic(bool prefer);
         public bool GetPreferPublic();
+        public void SetArchivedCatalogs(bool archived);
+        public bool GetArchivedCatalogs();
     }
 }

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Loaders/ValidatingXmlLoader.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Loaders/ValidatingXmlLoader.cs
@@ -6,7 +6,7 @@ using Org.XmlResolver.Catalog.Entry;
 using Org.XmlResolver.Utils;
 
 namespace Org.XmlResolver.Loaders {
-    public class ValidatingXmlLoader : CatalogLoader {
+    public class ValidatingXmlLoader : ICatalogLoader {
         protected static ResolverLogger logger = new ResolverLogger(LogManager.GetCurrentClassLogger());
         protected readonly Dictionary<Uri,EntryCatalog> catalogMap;
 
@@ -61,6 +61,14 @@ namespace Org.XmlResolver.Loaders {
 
         public bool GetPreferPublic() {
             return underlyingLoader.GetPreferPublic();
+        }
+
+        public void SetArchivedCatalogs(bool archived) {
+            underlyingLoader.SetArchivedCatalogs(archived);
+        }
+
+        public bool GetArchivedCatalogs() {
+            return underlyingLoader.GetArchivedCatalogs();
         }
     }
 }

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Loaders/XmlLoader.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Loaders/XmlLoader.cs
@@ -11,7 +11,7 @@ using Org.XmlResolver.Features;
 using Org.XmlResolver.Utils;
 
 namespace Org.XmlResolver.Loaders {
-    public class XmlLoader : CatalogLoader {
+    public class XmlLoader : ICatalogLoader {
         private readonly object _syncLock = new object();
         protected static ResolverLogger logger = new ResolverLogger(LogManager.GetCurrentClassLogger());
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.2.1
+version=0.3.0


### PR DESCRIPTION
# Fix additional catalogs

Make sure that the `ADDITIONAL_CATALOGS` feature works.

Close #3

# Fix assembly catalogs

The `ASSEMBLY_CATALOG` feature implementation was confused. The feature was treated as if it was a string, but in fact it's a list of strings.

1. Rename the feature `ASSEMBLY_CATALOGS` (with an "S" on the end)
2. `GetFeature` returns a list of strings (as it always did, though this caused an casting error)
3. `SetFeature` accepts a single string, which it adds to the assembly catalog list. This is backwards compatible behavior. It also accepts a list of strings, in which case it replaces the entire list. If `null` is passed, the list is cleared.

Close #10 

# Catalog loader

Add the archived catalog methods to the interface and rename it to `ICatalogLoader`.

Close #11

# Bump version to 0.3.0

In preparation for a new NuGet package. Breaking changes to interfaces probably mandate a major version change, but I'm giving myself freedom to ignore that as long as the major version is `0`.