### PR TITLE
Test subclasses

### DIFF
--- a/XmlResolver/UnitTests/CacheSubclass.cs
+++ b/XmlResolver/UnitTests/CacheSubclass.cs
@@ -1,0 +1,15 @@
+using Org.XmlResolver;
+using Org.XmlResolver.Cache;
+
+namespace UnitTests {
+    public class CacheSubclass: ResourceCache {
+        public CacheSubclass(XmlResolverConfiguration config) : base(config) {
+            // nop
+        }
+
+        public new string GetDirectory() {
+            return "";
+        }
+        
+    }
+}

--- a/XmlResolver/UnitTests/CacheSubclassTest.cs
+++ b/XmlResolver/UnitTests/CacheSubclassTest.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using Org.XmlResolver;
+using Org.XmlResolver.Cache;
+using Org.XmlResolver.Features;
+
+namespace UnitTests {
+    public class CacheSubclassTest {
+        private XmlResolverConfiguration config;
+
+        [SetUp]
+        public void Setup() {
+            config = new XmlResolverConfiguration();
+        }
+        
+        [Test]
+        public void TestFeatureCache() {
+            // Test that a subclass of ResourceCache can be used as a ResourceCache.
+            Assert.True(config.GetFeatures().Contains(ResolverFeature.CACHE));
+            CacheSubclass myCache = new CacheSubclass(config);
+            ResourceCache orig = (ResourceCache)config.GetFeature(ResolverFeature.CACHE);
+            config.SetFeature(ResolverFeature.CACHE, myCache);
+            Assert.AreSame(myCache, config.GetFeature(ResolverFeature.CACHE));
+            config.SetFeature(ResolverFeature.CACHE, orig);
+        }
+
+    }
+}


### PR DESCRIPTION
There was some question (in my mind at least) about whether subclasses could be used as resolver features. This trivial test demonstrates that they can.