### PR TITLE
Avoid throwing exceptions for resources not found

### DIFF
--- a/XmlResolver/UnitTests/ResolverTest.cs
+++ b/XmlResolver/UnitTests/ResolverTest.cs
@@ -22,6 +22,32 @@ namespace UnitTests {
         }
         
         [Test]
+        public void LookupSystemFail() {
+            try {
+                CatalogResolver cresolver = resolver.CatalogResolver;
+
+                ResolvedResource rsrc = cresolver.ResolveEntity(null, null, "https://example.com/not/in/catalog", null);
+
+                Assert.Null(rsrc);
+            } catch (Exception) {
+                Assert.Fail();
+            }
+        }
+
+        [Test]
+        public void LookupLocalSystemFail() {
+            try {
+                CatalogResolver cresolver = resolver.CatalogResolver;
+
+                ResolvedResource rsrc = cresolver.ResolveEntity(null, null, "file:///path/to/thing/that/isnt/likely/to/exist", null);
+
+                Assert.Null(rsrc);
+            } catch (Exception) {
+                Assert.Fail();
+            }
+        }
+
+        [Test]
         public void LookupSystem() {
             try {
                 Uri result = UriUtils.Resolve(TEST_ROOT_DIRECTORY, "XmlResolver/UnitTests/resources/sample10/sample.dtd");

--- a/XmlResolver/XmlResolver/Org/XmlResolver/CatalogResolver.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/CatalogResolver.cs
@@ -37,12 +37,18 @@ namespace Org.XmlResolver {
         }
 
         private ResolvedResourceImpl Resource(string requestUri, Uri responseUri, CacheEntry cached) {
-            if (cached == null) {
-                return UncachedResource(new Uri(requestUri), responseUri);
-            }
-            else {
+            try {
+                if (cached == null) {
+                    return UncachedResource(new Uri(requestUri), responseUri);
+                }
+
                 var fs = File.Open(cached.CacheFile.ToString(), FileMode.Open, FileAccess.Read);
-                return new ResolvedResourceImpl(responseUri, new Uri(cached.CacheFile.ToString()), fs, cached.ContentType());
+                return new ResolvedResourceImpl(responseUri, new Uri(cached.CacheFile.ToString()), fs,
+                    cached.ContentType());
+            }
+            catch (Exception ex) {
+                logger.Log(ResolverLogger.TRACE, "Failed to resolve {0}: {1}", requestUri, ex.Message);
+                return null;
             }
         }
 


### PR DESCRIPTION
If you attempt to resolve a resource and the resource isn't found, even if the resolver goes off and tries to cache the underlying resource to return it, failure to find/load/access the resource should not cause the resolver to throw an exception. The resolver simply returns `null` to indicate that it failed.
