### PR TITLE
Work around System.Xml public identifier bug

### DIFF
--- a/XmlResolver/UnitTests/PiTest.cs
+++ b/XmlResolver/UnitTests/PiTest.cs
@@ -31,7 +31,8 @@ namespace UnitTests {
                     // nop;
                 }
             }
-            catch (Exception) {
+            catch (Exception ex) {
+                Console.WriteLine(ex.Message);
                 Assert.Fail();
             }
         }
@@ -48,7 +49,8 @@ namespace UnitTests {
                     // nop;
                 }
             }
-            catch (Exception) {
+            catch (Exception ex) {
+                Console.WriteLine(ex.Message);
                 Assert.Fail();
             }
 

--- a/XmlResolver/UnitTests/PublicIdTest.cs
+++ b/XmlResolver/UnitTests/PublicIdTest.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Reflection;
+using System.Xml;
+using NUnit.Framework;
+using Org.XmlResolver;
+using Org.XmlResolver.Tools;
+using Org.XmlResolver.Utils;
+
+namespace UnitTests {
+    public class PublicIdTest {
+        private XmlResolverConfiguration config = null;
+        private Resolver resolver = null;
+
+        [SetUp]
+        public void Setup() {
+            config = new XmlResolverConfiguration();
+            config.AddCatalog(UriUtils.GetLocationUri("resources/parse/catalog.xml", Assembly.GetExecutingAssembly()).ToString());
+            resolver = new Resolver(config);
+        }
+        
+        [Test]
+        public void PublicTest() {
+            Uri docuri = UriUtils.GetLocationUri("resources/parse/doc.xml", Assembly.GetExecutingAssembly());
+            XmlReaderSettings settings = new XmlReaderSettings();
+            settings.DtdProcessing = DtdProcessing.Parse;
+            
+            ResolvingXmlReader reader = new ResolvingXmlReader(docuri, settings, resolver);
+            try {
+                while (reader.Read()) {
+                    // nop;
+                }
+            }
+            catch (Exception) {
+                Assert.Fail();
+            }
+        }
+
+    }
+}

--- a/XmlResolver/UnitTests/resources/parse/catalog.xml
+++ b/XmlResolver/UnitTests/resources/parse/catalog.xml
@@ -4,6 +4,9 @@
   <system systemId="http://example.org/schema/doc.dtd"
           uri="doc.dtd"/>
 
+  <public publicId="-//DTD//Example 1.0//EN"
+          uri="doc.dtd"/>
+
   <system systemId="http://example.org/schema/doc.xsd"
           uri="doc.xsd"/>
 

--- a/XmlResolver/UnitTests/resources/parse/doc.xml
+++ b/XmlResolver/UnitTests/resources/parse/doc.xml
@@ -1,4 +1,5 @@
-<!DOCTYPE doc SYSTEM "http://example.org/schema/doc.dtd">
+<!DOCTYPE doc PUBLIC "-//DTD//Example 1.0//EN"
+              "http://example.org/schema/doc.dtd">
 <doc xmlns="http://example.org/ns/document"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://example.org/ns/document

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Cache/ResourceCache.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Cache/ResourceCache.cs
@@ -474,6 +474,10 @@ namespace Org.XmlResolver.Cache {
         }
 
         public CacheEntry CachedSystem(Uri systemId, string publicId) {
+            if (systemId == null) {
+                return null;
+            }
+
             CacheEntry entry = FindSystemCacheEntry(systemId.ToString());
             if (entry == null || entry.Expired) {
                 if (CacheUri(systemId.ToString())) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.5.1
+version=0.5.2


### PR DESCRIPTION
Fix #25 

There's no good way to use the bogus URI-that-contains-a-public-identifier. The best we can do is return "null" without attempting to dereference the URI. That should improve the performance, at least.