### PR TITLE
Clean up the public identifier fix

### DIFF
--- a/XmlResolver/UnitTests/PublicIdTest.cs
+++ b/XmlResolver/UnitTests/PublicIdTest.cs
@@ -34,6 +34,5 @@ namespace UnitTests {
                 Assert.Fail();
             }
         }
-
     }
 }


### PR DESCRIPTION
Move the fix into the `ResolveEntity` method.