### PR TITLE
Search for assemblies and small fixes

### DIFF
--- a/XmlResolver/SampleApp/Program.cs
+++ b/XmlResolver/SampleApp/Program.cs
@@ -15,7 +15,8 @@ namespace SampleApp {
             XmlResolverConfiguration config = new XmlResolverConfiguration();
             // The SampleApp refers to the XmlResolverData NuGet, so I can assume all of
             // the common resources in that assembly will be available.
-            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, "XmlResolverData.dll");
+            //config.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, "XmlResolverData.dll");
+            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, "./mydata.dll");
 
             string document = null;
             

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.6.0
+version=0.6.1


### PR DESCRIPTION
1. Fix #35 by searching for assemblies in the application's `Assembly.GetExecutingAssembly().Location` if the requested assembly file doesn't contain either forward or backward slashes. So, for example, attempting to load `XmlResolverData.dll` will work if you've added that package to your project.
2. Cache resolved assembly locations so we don't keep looking for them over and over again.
3. When constructing the list of catalogs, avoid returning duplicates.
