### PR TITLE
Clean up file access in the cache

### DIFF
--- a/XmlResolver/UnitTests/CMNextTest.cs
+++ b/XmlResolver/UnitTests/CMNextTest.cs
@@ -5,11 +5,17 @@ using Org.XmlResolver.Utils;
 
 namespace UnitTests {
     public class CMNextTest : BaseTestRoot {
-        private readonly Uri baseUri = new Uri("file:///tmp/");
+        private Uri baseUri = new Uri("file:///tmp/");
         private CatalogManager manager = null;
 
         [SetUp]
         public void Setup() {
+            if (TEST_ROOT_PATH[1] == ':')
+            {
+                // Fix the path for Windows
+                baseUri = new Uri("file:///" + TEST_ROOT_PATH[0] + ":/tmp/");
+            }
+            
             XmlResolverConfiguration config = new XmlResolverConfiguration();
             config.AddCatalog(UriUtils.Resolve(TEST_ROOT_DIRECTORY, "XmlResolver/UnitTests/resources/cm/nextroot.xml").ToString());
             config.AddCatalog(UriUtils.Resolve(TEST_ROOT_DIRECTORY, "XmlResolver/UnitTests/resources/cm/following.xml").ToString());

--- a/XmlResolver/UnitTests/CacheManager.cs
+++ b/XmlResolver/UnitTests/CacheManager.cs
@@ -5,10 +5,9 @@ namespace UnitTests {
     public class CacheManager : ResolverTest {
         public FileInfo ClearCache(string relpath) {
             string cache = Path.Combine(Environment.CurrentDirectory, relpath);
-            if (File.Exists(cache)) {
+            if (Directory.Exists(cache)) {
                 Directory.Delete(cache, true);
             }
-
             return new FileInfo(cache);
         }
     }

--- a/XmlResolver/UnitTests/CacheTest.cs
+++ b/XmlResolver/UnitTests/CacheTest.cs
@@ -23,6 +23,12 @@ namespace UnitTests {
             cache = new ResourceCache(config);
             cresolver = new CatalogResolver(config);
         }
+        
+        [TearDown]
+        public void Teardown()
+        {
+            ClearCache(cacheDir);
+        }
 
         [Test]
         public void DefaultInfo() {
@@ -121,7 +127,9 @@ namespace UnitTests {
             try {
                 ResolvedResource rsrc = cresolver.ResolveUri("http://localhost:8222/docs/sample/xlink.xsd", null);
                 Assert.NotNull(rsrc.GetInputStream());
-            } catch (Exception) {
+                rsrc.GetInputStream().Close();
+            } catch (Exception ex) {
+                Console.WriteLine(ex.Message);
                 Assert.Fail();
             }
         }

--- a/XmlResolver/UnitTests/ResolverTest.cs
+++ b/XmlResolver/UnitTests/ResolverTest.cs
@@ -41,7 +41,9 @@ namespace UnitTests {
                 ResolvedResource rsrc = cresolver.ResolveEntity(null, null, "file:///path/to/thing/that/isnt/likely/to/exist", null);
 
                 Assert.Null(rsrc);
-            } catch (Exception) {
+            } catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
                 Assert.Fail();
             }
         }
@@ -56,7 +58,8 @@ namespace UnitTests {
 
                 Assert.NotNull(rsrc.GetInputStream());
                 Assert.AreEqual(result, rsrc.GetLocalUri());
-            } catch (Exception) {
+            } catch (Exception ex) {
+                Console.WriteLine(ex.Message);
                 Assert.Fail();
             }
         }

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Cache/CacheEntryCatalog.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Cache/CacheEntryCatalog.cs
@@ -95,52 +95,71 @@ namespace Org.XmlResolver.Cache {
             return entry;
         }
 
-        internal void WriteCacheEntry(Entry entry, string cacheFile) {
-            // Constructing XML with print statements is kind of grotty, but...
-            using (StreamWriter xml = new StreamWriter(cacheFile)) {
-                switch (entry.GetEntryType()) {
-                    case EntryType.URI:
-                        EntryUri uri = (EntryUri) entry;
-                        xml.WriteLine("<uri xmlns='" + ResolverConstants.CATALOG_NS + "'");
-                        xml.WriteLine("<uri xmlns='" + ResolverConstants.CATALOG_NS + "'");
-                        xml.WriteLine("     xmlns:xr='" + ResolverConstants.XMLRESOURCE_EXT_NS + "'");
-                        xml.WriteLine("     name='" + XmlEscape(uri.Name) + "'");
-                        xml.WriteLine("     uri='" + XmlEscape(uri.ResourceUri.ToString()) + "'");
-                        if (uri.Nature != null) {
-                            xml.WriteLine("     nature='" + XmlEscape(uri.Nature) + "'");
-                        }
-                        if (uri.Purpose != null) {
-                            xml.WriteLine("     purpose='" + XmlEscape(uri.Purpose) + "'");
-                        }
+        internal void WriteCacheEntry(Entry entry, string cacheFile)
+        {
+            FileStream cacheStream = null;
+            try
+            {
+                cacheStream = File.Open(cacheFile, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
 
-                        break;
-                    case EntryType.SYSTEM:
-                        EntrySystem system = (EntrySystem) entry;
-                        xml.WriteLine("<system xmlns='" + ResolverConstants.CATALOG_NS + "'");
-                        xml.WriteLine("        xmlns:xr='" + ResolverConstants.XMLRESOURCE_EXT_NS + "'");
-                        xml.WriteLine("        systemId='" + XmlEscape(system.SystemId) + "'");
-                        xml.WriteLine("        uri='" + XmlEscape(system.ResourceUri.ToString()) + "'");
-                        break;
-                    case EntryType.PUBLIC:
-                        EntryPublic pub = (EntryPublic) entry;
-                        xml.WriteLine("<public xmlns='" + ResolverConstants.CATALOG_NS + "'");
-                        xml.WriteLine("        xmlns:xr='" + ResolverConstants.XMLRESOURCE_EXT_NS + "'");
-                        xml.WriteLine("        publicId='" + XmlEscape(pub.PublicId) + "'");
-                        xml.WriteLine("        uri='" + XmlEscape(pub.ResourceUri.ToString()) + "'");
-                        break;
-                    default:
-                        Error("Attempt to write unexpected entry type");
-                        break;
-                }
-                
-                foreach (string name in entry.GetProperties().Keys)
+                // Constructing XML with print statements is kind of grotty, but...
+                using (StreamWriter xml = new StreamWriter(cacheStream))
                 {
-                    if (entry.GetProperty(name) != null) {
-                        xml.WriteLine("     xr:" + name + "='" + XmlEscape(entry.GetProperty(name)) + "'");
-                    }
-                }
+                    switch (entry.GetEntryType())
+                    {
+                        case EntryType.URI:
+                            EntryUri uri = (EntryUri) entry;
+                            xml.WriteLine("<uri xmlns='" + ResolverConstants.CATALOG_NS + "'");
+                            xml.WriteLine("     xmlns:xr='" + ResolverConstants.XMLRESOURCE_EXT_NS + "'");
+                            xml.WriteLine("     name='" + XmlEscape(uri.Name) + "'");
+                            xml.WriteLine("     uri='" + XmlEscape(uri.ResourceUri.ToString()) + "'");
+                            if (uri.Nature != null)
+                            {
+                                xml.WriteLine("     nature='" + XmlEscape(uri.Nature) + "'");
+                            }
 
-                xml.WriteLine("/>");
+                            if (uri.Purpose != null)
+                            {
+                                xml.WriteLine("     purpose='" + XmlEscape(uri.Purpose) + "'");
+                            }
+
+                            break;
+                        case EntryType.SYSTEM:
+                            EntrySystem system = (EntrySystem) entry;
+                            xml.WriteLine("<system xmlns='" + ResolverConstants.CATALOG_NS + "'");
+                            xml.WriteLine("        xmlns:xr='" + ResolverConstants.XMLRESOURCE_EXT_NS + "'");
+                            xml.WriteLine("        systemId='" + XmlEscape(system.SystemId) + "'");
+                            xml.WriteLine("        uri='" + XmlEscape(system.ResourceUri.ToString()) + "'");
+                            break;
+                        case EntryType.PUBLIC:
+                            EntryPublic pub = (EntryPublic) entry;
+                            xml.WriteLine("<public xmlns='" + ResolverConstants.CATALOG_NS + "'");
+                            xml.WriteLine("        xmlns:xr='" + ResolverConstants.XMLRESOURCE_EXT_NS + "'");
+                            xml.WriteLine("        publicId='" + XmlEscape(pub.PublicId) + "'");
+                            xml.WriteLine("        uri='" + XmlEscape(pub.ResourceUri.ToString()) + "'");
+                            break;
+                        default:
+                            Error("Attempt to write unexpected entry type");
+                            break;
+                    }
+
+                    foreach (string name in entry.GetProperties().Keys)
+                    {
+                        if (entry.GetProperty(name) != null)
+                        {
+                            xml.WriteLine("     xr:" + name + "='" + XmlEscape(entry.GetProperty(name)) + "'");
+                        }
+                    }
+
+                    xml.WriteLine("/>");
+                }
+            }
+            finally
+            {
+                if (cacheStream != null)
+                {
+                    cacheStream.Close();
+                }
             }
         }
 

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Cache/DirectoryLock.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Cache/DirectoryLock.cs
@@ -3,8 +3,9 @@ using System.IO;
 using System.Threading;
 
 namespace Org.XmlResolver.Cache {
-    public class DirectoryLock {
-        public static int retryCount = 10;
+    public class DirectoryLock
+    {
+        public static int retryCount = 30; // ~15 seconds
         private FileStream lockStream = null;
 
         public DirectoryLock(string dir) {
@@ -12,11 +13,10 @@ namespace Org.XmlResolver.Cache {
             int count = retryCount;
             while (true) {
                 try {
-                    lockStream = File.Open(lockfn, FileMode.OpenOrCreate, FileAccess.Read, FileShare.None);
+                    lockStream = File.Open(lockfn, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
                     return;
                 }
                 catch (IOException) {
-                    Console.WriteLine("Failed to get lock, waiting...");
                     count--;
                     if (count <= 0) {
                         throw;

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Utils/UriUtils.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Utils/UriUtils.cs
@@ -334,6 +334,12 @@ namespace Org.XmlResolver.Utils {
                 fn = uri.Substring(5);
             }
 
+            // What about /C:/path/to/thing?
+            if (fn.Length >= 3 && fn[2] == ':')
+            {
+                fn = fn.Substring(1);
+            }
+
             // If this looks like /C:/path/to/thing, make it C:/path/to/thing
             if (fn.Length >= 3 && fn[0] == '/' && fn[2] == ':') {
                 fn = fn.Substring(1);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.6.1
+version=0.7.0


### PR DESCRIPTION
Close #37 

This PR fixes the cache so that it's more careful about file access and closing files. All access to the cache control file is now exclusively locked. Cache entry access now properly closes the files when it's finished.

This also fixes a bug associated with converting filenames to URIs for reading local files. Previously, drive letters were not considered so "file:///c:/path" would become "/c:/path" instead of "c:/path".