### PR TITLE
Use the assembly.FullName for version info

### DIFF
--- a/XmlResolver/XmlResolver/Org/XmlResolver/XmlResolverConfiguration.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/XmlResolverConfiguration.cs
@@ -162,8 +162,7 @@ namespace Org.XmlResolver {
         /// <param name="catalogFiles"></param>
         public XmlResolverConfiguration(List<Uri> propertyFiles, List<string> catalogFiles) {
             Assembly assembly = Assembly.GetExecutingAssembly();
-            FileVersionInfo fileVersion = FileVersionInfo.GetVersionInfo(assembly.Location);
-            logger.Log(ResolverLogger.CONFIG, "XMLResolver version " + fileVersion.FileVersion);
+            logger.Log(ResolverLogger.CONFIG, assembly.FullName);
             showConfigChanges = false;
             catalogs.Clear();
             additionalCatalogs.Clear();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-resolverVersion=1.0.0
+resolverVersion=1.1.0


### PR DESCRIPTION
Close #41 

Don't rely on the `assembly.Location`. It's just for a log message anyway.
