### PR TITLE
Change the default value for URI_FOR_SYSTEM to true

### DIFF
--- a/XmlResolver/UnitTests/Issue48.cs
+++ b/XmlResolver/UnitTests/Issue48.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Xml;
+using NUnit.Framework;
+using Org.XmlResolver;
+using Org.XmlResolver.Features;
+
+namespace UnitTests {
+    public class Issue48 {
+        [Test]
+        public void testResolver() {
+            var resolverConfig = new XmlResolverConfiguration();
+            resolverConfig.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, "XmlResolverData.dll");
+            //resolverConfig.SetFeature(ResolverFeature.URI_FOR_SYSTEM, true);
+
+            var resolver = new Resolver(resolverConfig);
+
+            string uri = "https://www.w3.org/TR/xslt-30/schema-for-xslt30.xsd";
+
+            Console.WriteLine(resolver.ResolveUri(null, uri));
+
+            using (XmlReader xmlReader = XmlReader.Create(uri, new XmlReaderSettings() { DtdProcessing = DtdProcessing.Parse, XmlResolver = resolver, Async = false}))
+            {
+                while (xmlReader.Read())
+                {
+                    Console.WriteLine(xmlReader.ReadOuterXml());
+                }
+            }
+        }
+    }
+}

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Features/ResolverFeature.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Features/ResolverFeature.cs
@@ -54,7 +54,7 @@ namespace Org.XmlResolver.Features {
         }
         
         public static readonly ListOfStringResolverFeature CATALOG_FILES = register(new ListOfStringResolverFeature(
-            "http://xmlresolver.org/feature/catalog-files1", new()));
+            "http://xmlresolver.org/feature/catalog-files", new()));
 
         public static readonly ListOfStringResolverFeature CATALOG_ADDITIONS = register(new ListOfStringResolverFeature(
             "http://xmlresolver.org/feature/catalog-additions", new()));

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Features/ResolverFeature.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Features/ResolverFeature.cs
@@ -81,7 +81,7 @@ namespace Org.XmlResolver.Features {
             "http://xmlresolver.org/feature/catalog-manager", null));
 
         public static readonly BoolResolverFeature URI_FOR_SYSTEM = register(new BoolResolverFeature(
-            "http://xmlresolver.org/feature/uri-for-system", false));
+            "http://xmlresolver.org/feature/uri-for-system", true));
 
         public static readonly BoolResolverFeature MERGE_HTTPS = register(new BoolResolverFeature(
             "http://xmlresolver.org/feature/merge-https", true));

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-resolverVersion=1.2.0
+resolverVersion=1.3.0


### PR DESCRIPTION
Justification:
1. The setting needs to be true to take full advantage of the XmlResolverData assembly.
2. It's true by default in the Java resolver
3. All of the other defaults are permissive (parse RDDL files, treat http: and https: as the same, use a cache, etc.)

Close #48 

(Thank you, @martin-honnen !)