### PR TITLE
Bump XmlResolverData assembly references to 1.1.0

### DIFF
--- a/XmlResolver/SampleApp/SampleApp.csproj
+++ b/XmlResolver/SampleApp/SampleApp.csproj
@@ -18,7 +18,7 @@
     <ItemGroup>
       <PackageReference Include="NuGet.Frameworks" Version="5.10.0" />
       <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
-      <PackageReference Include="XmlResolverData" Version="1.0.1" />
+      <PackageReference Include="XmlResolverData" Version="1.1.0" />
 
     </ItemGroup>
 

--- a/XmlResolver/UnitTests/UnitTests.csproj
+++ b/XmlResolver/UnitTests/UnitTests.csproj
@@ -261,7 +261,7 @@
 
         <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
 
-        <PackageReference Include="XmlResolverData" Version="1.0.1" />
+        <PackageReference Include="XmlResolverData" Version="1.1.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
I don't believe this has any actual effect except in the unit tests and the sample app. The XmlResolver itself doesn't refer to the data assembly.