### PR TITLE
Added a feature to fix windows system identifiers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202111-02
 
     java:
       version: oraclejdk8

--- a/XmlResolver/XmlResolver/Org/XmlResolver/CatalogManager.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/CatalogManager.cs
@@ -107,6 +107,16 @@ namespace Org.XmlResolver {
         public EntryCatalog LoadCatalog(Uri catalog, Stream data) {
             return _catalogLoader.LoadCatalog(catalog, data);
         }
+
+        private String fixWindowsSystemIdentifier(String systemId)
+        {
+            if (UriUtils.isWindows() && (bool) _resolverConfiguration.GetFeature(ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS))
+            {
+                return systemId.Replace("\\", "/");
+            }
+
+            return systemId;
+        }
         
         /// <summary>
         /// Lookup a URI.
@@ -149,7 +159,9 @@ namespace Org.XmlResolver {
         /// <param name="systemId">The system identifier for the entity.</param>
         /// <param name="publicId">The public identifier for the entity.</param>
         /// <returns>The resolved URI or null if no matching entry could be found.</returns>
-        public virtual Uri LookupPublic(string systemId, string publicId) {
+        public virtual Uri LookupPublic(string systemId, string publicId)
+        {
+            systemId = fixWindowsSystemIdentifier(systemId);
             ExternalIdentifiers external = NormalizeExternalIdentifiers(systemId, publicId);
             return new QueryPublic(external.SystemId, external.PublicId).Search(this).ResultUri();
         }
@@ -165,7 +177,9 @@ namespace Org.XmlResolver {
         /// corresponding public identifier and against <c>public</c> entries.</para>
         /// <param name="systemId">The system identifier for the entity.</param>
         /// <returns>The resolved URI or null if no matching entry could be found.</returns>
-        public virtual Uri LookupSystem(string systemId) {
+        public virtual Uri LookupSystem(string systemId) 
+        {
+            systemId = fixWindowsSystemIdentifier(systemId);
             ExternalIdentifiers external = NormalizeExternalIdentifiers(systemId, null);
             if (external.SystemId == null) {
                 return null;
@@ -184,7 +198,9 @@ namespace Org.XmlResolver {
         /// <param name="systemId">The system identifier, may be null.</param>
         /// <param name="publicId">The public identifier, may be null.</param>
         /// <returns>The resolved URI or null if no matching entry could be found.</returns>
-        public virtual Uri LookupDoctype(string entityName, string systemId, string publicId) {
+        public virtual Uri LookupDoctype(string entityName, string systemId, string publicId) 
+        {
+            systemId = fixWindowsSystemIdentifier(systemId);
             ExternalIdentifiers external = NormalizeExternalIdentifiers(systemId, publicId);
             return new QueryDoctype(entityName, external.SystemId, external.PublicId).Search(this).ResultUri();
         }
@@ -199,7 +215,9 @@ namespace Org.XmlResolver {
         /// <param name="systemId">The system identifier, may be null.</param>
         /// <param name="publicId">The public identifier, may be null.</param>
         /// <returns>The resolved URI or null if no matching entry could be found.</returns>
-        public virtual Uri LookupEntity(string entityName, string systemId, string publicId) {
+        public virtual Uri LookupEntity(string entityName, string systemId, string publicId)
+        {
+            systemId = fixWindowsSystemIdentifier(systemId);
             ExternalIdentifiers external = NormalizeExternalIdentifiers(systemId, publicId);
             return new QueryEntity(entityName, external.SystemId, external.PublicId).Search(this).ResultUri();
         }
@@ -214,7 +232,9 @@ namespace Org.XmlResolver {
         /// <param name="systemId">The system identifier, may be null.</param>
         /// <param name="publicId">The public identifier, may be null.</param>
         /// <returns>The resolved URI or null if no matching entry could be found.</returns>
-        public Uri LookupNotation(string notationName, string systemId, string publicId) {
+        public Uri LookupNotation(string notationName, string systemId, string publicId) 
+        {
+            systemId = fixWindowsSystemIdentifier(systemId);
             ExternalIdentifiers external = NormalizeExternalIdentifiers(systemId, publicId);
             return new QueryNotation(notationName, external.SystemId, external.PublicId).Search(this).ResultUri();
         }

--- a/XmlResolver/XmlResolver/Org/XmlResolver/CatalogResolver.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/CatalogResolver.cs
@@ -221,6 +221,11 @@ namespace Org.XmlResolver {
                 return null;
             }
 
+            if (UriUtils.isWindows() && (bool) config.GetFeature(ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS))
+            {
+                systemId = systemId.Replace("\\", "/");
+            }
+            
             if (name != null && publicId == null && systemId == null) {
                 logger.Log(ResolverLogger.REQUEST, "ResolveEntity: name: {0} ({1})", name, baseUri);
                 return ResolveDoctype(name, baseUri);

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Features/ResolverFeature.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Features/ResolverFeature.cs
@@ -107,5 +107,8 @@ namespace Org.XmlResolver.Features {
         public static readonly BoolResolverFeature CACHE_ENABLED = register(new BoolResolverFeature(
             "http://xmlresolver.org/feature/cache-enbled", true));
 
+        public static readonly BoolResolverFeature FIX_WINDOWS_SYSTEM_IDENTIFIERS = register(new BoolResolverFeature(
+            "http://xmlresolver.org/feature/fix-windows-system-identifiers", false));
+
     }
 }

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Utils/UriUtils.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Utils/UriUtils.cs
@@ -5,6 +5,7 @@ using System.IO.Compression;
 using System.IO.Packaging;
 using System.Net;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Org.XmlResolver.Utils {
@@ -18,6 +19,15 @@ namespace Org.XmlResolver.Utils {
     /// that may arise (because resources aren't found, for example, or aren't accessible.</para>
     /// 
     public class UriUtils {
+        /// <summary>
+        /// Report if the platform is Windows.
+        /// </summary>
+        /// <returns>True if the platform is Windows, false otherwise.</returns>
+        public static Boolean isWindows()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+        
         /// <summary>
         /// Resolve a string against a base URI, taking special care of pack: URIs.
         /// </summary>

--- a/XmlResolver/XmlResolver/Org/XmlResolver/XmlResolverConfiguration.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/XmlResolverConfiguration.cs
@@ -104,7 +104,7 @@ namespace Org.XmlResolver {
             ResolverFeature.MERGE_HTTPS, ResolverFeature.MASK_PACK_URIS,
             ResolverFeature.CATALOG_MANAGER, ResolverFeature.URI_FOR_SYSTEM, ResolverFeature.CATALOG_LOADER_CLASS,
             ResolverFeature.PARSE_RDDL, ResolverFeature.ASSEMBLY_CATALOGS, ResolverFeature.ARCHIVED_CATALOGS,
-            ResolverFeature.USE_DATA_ASSEMBLY
+            ResolverFeature.USE_DATA_ASSEMBLY, ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS
         };
 
         // private static List<string> classpathCatalogList = null;
@@ -129,6 +129,7 @@ namespace Org.XmlResolver {
         private bool parseRddl = ResolverFeature.PARSE_RDDL.GetDefaultValue();
         private bool archivedCatalogs = ResolverFeature.ARCHIVED_CATALOGS.GetDefaultValue();
         private bool useDataAssembly = ResolverFeature.USE_DATA_ASSEMBLY.GetDefaultValue();
+        private bool fixWindowsSystemIdentifiers = ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS.GetDefaultValue();
         private bool showConfigChanges = false; // make the config process a bit less chatty
         
         /// <summary>
@@ -207,6 +208,7 @@ namespace Org.XmlResolver {
             archivedCatalogs = current.archivedCatalogs;
             useDataAssembly = current.useDataAssembly;
             showConfigChanges = current.showConfigChanges;
+            fixWindowsSystemIdentifiers = current.fixWindowsSystemIdentifiers;
         }
 
         private void LoadConfiguration(List<Uri> propertyFiles, List<string> catalogFiles) {
@@ -337,6 +339,7 @@ namespace Org.XmlResolver {
             SetBoolean("XML_CATALOG_URI_FOR_SYSTEM", "URI-for-system: {0}", ref uriForSystem);
             SetBoolean("XML_CATALOG_MERGE_HTTPS", "Merge https: {0}", ref mergeHttps);
             SetBoolean("XML_CATALOG_MASK_PACK_URIS", "Mask-pack-URIs: {0}", ref maskPackUris);
+            SetBoolean("XML_CATALOG_FIX_WINDOWS_SYSTEM_IDENTIFIERS", "Fix Windows system identifiers: {0}", ref fixWindowsSystemIdentifiers);
             
             property = Environment.GetEnvironmentVariable("XML_CATALOG_LOADER_CLASS");
             if (property != null) {
@@ -450,6 +453,7 @@ namespace Org.XmlResolver {
             SetPropertyBoolean(section.GetSection("uriForSystem"), "URI-for-system: {0}", ref uriForSystem);
             SetPropertyBoolean(section.GetSection("mergeHttps"), "Merge https: {0}", ref mergeHttps);
             SetPropertyBoolean(section.GetSection("maskPackUris"), "Mask-pack-URIs: {0}", ref maskPackUris);
+            SetPropertyBoolean(section.GetSection("fixWindowsSystemIdentifiers"), "Fix Windows system identifiers: {0}", ref fixWindowsSystemIdentifiers);
             
             property = section.GetSection("catalogLoaderClass");
             if (property.Value != null) {
@@ -617,6 +621,8 @@ namespace Org.XmlResolver {
                 if (useDataAssembly) {
                     builtinAssemblyCatalogs.Add(XmlResolverDataAssembly);
                 }
+            } else if (feature == ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS) {
+                fixWindowsSystemIdentifiers = (Boolean) value;
             } else {
                 logger.Log(ResolverLogger.ERROR, "Ignoring unknown feature: %s", feature.GetFeatureName());
             }        
@@ -701,6 +707,8 @@ namespace Org.XmlResolver {
                 return cacheUnderHome;
             } else if (feature == ResolverFeature.CACHE_ENABLED) {
                 return cacheEnabled;
+            } else if (feature == ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS) {
+                return fixWindowsSystemIdentifiers;
             } else {
                 logger.Log(ResolverLogger.ERROR, "Ignoring unknown feature: %s", feature.GetFeatureName());
                 return null;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-resolverVersion=1.3.0
+resolverVersion=1.4.0


### PR DESCRIPTION
Added a `FIX_WINDOWS_SYSTEM_IDENTIFIERS` feature. If true, on Windows systems, backslash characters in system identifiers are replaced with forward slashes before resolution is attempted. This avoids a URI syntax exception caused by the fact that, technically, backslashes are not allowed in URIs. 