### PR TITLE
Initial PR for version 2.0.0

### DIFF
--- a/XmlResolver/SampleApp/SampleApp.csproj
+++ b/XmlResolver/SampleApp/SampleApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/XmlResolver/UnitTests/ParserTest.cs
+++ b/XmlResolver/UnitTests/ParserTest.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Reflection;
+using System.Xml;
+using NUnit.Framework;
+using Org.XmlResolver;
+using Org.XmlResolver.Features;
+using Org.XmlResolver.Tools;
+using Org.XmlResolver.Utils;
+
+namespace UnitTests
+{
+    public class ParserTest
+    {
+        private XmlResolverConfiguration config = null;
+        private Resolver resolver = null;
+
+        [SetUp]
+        public void Setup() {
+            config = new XmlResolverConfiguration();
+            resolver = new Resolver(config);
+            config.SetFeature(ResolverFeature.ALLOW_CATALOG_PI, true);
+        }
+
+        [Test]
+        public void ParseWithRedirect()
+        {
+            Uri docuri = UriUtils.GetLocationUri("resources/xml/sample-dtd-redirect.xml", Assembly.GetExecutingAssembly());
+            XmlReaderSettings settings = new XmlReaderSettings();
+            settings.DtdProcessing = DtdProcessing.Parse;
+            
+            ResolvingXmlReader reader = new ResolvingXmlReader(docuri, settings, resolver);
+            try {
+                while (reader.Read())
+                {
+                    XmlNodeType ntype = reader.NodeType;
+                    if (ntype == XmlNodeType.Element)
+                    {
+                        Console.WriteLine("element");
+                    }
+                }
+            }
+            catch (Exception ex) {
+                Console.WriteLine(ex.Message);
+                Assert.Fail();
+            }
+        }
+    
+        [Test]
+        public void ParseWithRedirect2()
+        {
+            // This will redirect to https: 
+            Uri docuri = new Uri("http://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd");
+            XmlReaderSettings settings = new XmlReaderSettings();
+            settings.DtdProcessing = DtdProcessing.Parse;
+            
+            ResolvingXmlReader reader = new ResolvingXmlReader(docuri, settings, resolver);
+            try {
+                while (reader.Read())
+                {
+                    XmlNodeType ntype = reader.NodeType;
+                    if (ntype == XmlNodeType.Element)
+                    {
+                        Console.WriteLine("element");
+                    }
+                }
+            }
+            catch (Exception ex) {
+                Console.WriteLine(ex.Message);
+                Assert.Fail();
+            }
+        }
+        
+    }
+}

--- a/XmlResolver/UnitTests/ParserTest.cs
+++ b/XmlResolver/UnitTests/ParserTest.cs
@@ -32,11 +32,6 @@ namespace UnitTests
             try {
                 while (reader.Read())
                 {
-                    XmlNodeType ntype = reader.NodeType;
-                    if (ntype == XmlNodeType.Element)
-                    {
-                        Console.WriteLine("element");
-                    }
                 }
             }
             catch (Exception ex) {
@@ -57,11 +52,6 @@ namespace UnitTests
             try {
                 while (reader.Read())
                 {
-                    XmlNodeType ntype = reader.NodeType;
-                    if (ntype == XmlNodeType.Element)
-                    {
-                        Console.WriteLine("element");
-                    }
                 }
             }
             catch (Exception ex) {

--- a/XmlResolver/UnitTests/ResolverTestJar.cs
+++ b/XmlResolver/UnitTests/ResolverTestJar.cs
@@ -17,7 +17,7 @@ namespace UnitTests {
             config.SetFeature(ResolverFeature.URI_FOR_SYSTEM, true);
             config.SetFeature(ResolverFeature.CACHE, null);
             config.SetFeature(ResolverFeature.CACHE_UNDER_HOME, false);
-            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, "UnitTests.dll");
+            config.SetFeature(ResolverFeature.ASSEMBLY_CATALOGS, "UnitTests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
             resolver = new Resolver(config);
         }
         

--- a/XmlResolver/UnitTests/UnitTests.csproj
+++ b/XmlResolver/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
@@ -132,6 +132,9 @@
         <EmbeddedResource Include="resources/xml/sample-dtd.xml">
           <LogicalName>resources.xml.sample-dtd.xml</LogicalName>
         </EmbeddedResource>
+        <EmbeddedResource Include="resources/xml/sample-dtd-redirect.xml">
+          <LogicalName>resources.xml.sample-dtd-redirect.xml</LogicalName>
+        </EmbeddedResource>
         <EmbeddedResource Include="resources/seqtest2.xml">
           <LogicalName>resources.seqtest2.xml</LogicalName>
         </EmbeddedResource>
@@ -261,7 +264,7 @@
 
         <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
 
-        <PackageReference Include="XmlResolverData" Version="1.1.0" />
+        <PackageReference Include="XmlResolverData" Version="1.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/XmlResolver/UnitTests/resources/xml/sample-dtd-redirect.xml
+++ b/XmlResolver/UnitTests/resources/xml/sample-dtd-redirect.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE book PUBLIC "-//Sample//DTD Simple 1.0//EN"
+          "http://xmlresolver.org/ns/sample/sample.dtd">
+<book xmlns="https://xmlresolver.org/ns/sample">
+<title>A sample book</title>
+<article>
+<p>This book validates against DTD with both public and system identifiers.</p>
+</article>
+</book>

--- a/XmlResolver/XmlResolver.sln.DotSettings.user
+++ b/XmlResolver/XmlResolver.sln.DotSettings.user
@@ -1,5 +1,10 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=a595a3dd_002Ddd5c_002D4b60_002D85a0_002D82d8931f9dd8/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from &amp;lt;UnitTests&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
-  &lt;Project Location="/Volumes/Projects/xmlresolver/cs/XmlResolver/UnitTests" Presentation="&amp;lt;UnitTests&amp;gt;" /&gt;
+  &lt;Or&gt;
+    &lt;Project Location="/Volumes/Projects/xmlresolver/cs/XmlResolver/UnitTests" Presentation="&amp;lt;UnitTests&amp;gt;" /&gt;
+    &lt;TestAncestor&gt;
+      &lt;TestId&gt;NUnit3x::BB285ECA-8684-49AF-9A25-4B80E64B307C::net6.0::TestCS.Tests&lt;/TestId&gt;
+    &lt;/TestAncestor&gt;
+  &lt;/Or&gt;
 &lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Cache/ResourceCache.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Cache/ResourceCache.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Xml;
@@ -392,7 +393,7 @@ namespace Org.XmlResolver.Cache {
                 lastModified = conn.Date;
             }
 
-            if (conn.StatusCode != 200) {
+            if (conn.StatusCode != HttpStatusCode.OK) {
                 logger.Log(ResolverLogger.CACHE, "Not expired: {0} (HTTP {1})",
                     entry.CacheUri.ToString(), conn.StatusCode.ToString());
                 return false;
@@ -494,7 +495,7 @@ namespace Org.XmlResolver.Cache {
             if (entry == null || entry.Expired) {
                 if (CacheUri(uri.ToString())) {
                     ResourceConnection conn = new ResourceConnection(uri.ToString());
-                    if (conn.Stream != null && conn.StatusCode == 200) {
+                    if (conn.Stream != null && conn.StatusCode == HttpStatusCode.OK) {
                         entry = AddNamespaceUri(conn, nature, purpose);
                     }
                 }
@@ -513,7 +514,7 @@ namespace Org.XmlResolver.Cache {
             if (entry == null || entry.Expired) {
                 if (CacheUri(systemId.ToString())) {
                     ResourceConnection conn = new ResourceConnection(systemId.ToString());
-                    if (conn.Stream != null && conn.StatusCode == 200) {
+                    if (conn.Stream != null && conn.StatusCode == HttpStatusCode.OK) {
                         entry = AddSystem(conn);
                     }
                 }

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Catalog/Query/QueryCatalog.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Catalog/Query/QueryCatalog.cs
@@ -12,7 +12,8 @@ namespace Org.XmlResolver.Catalog.Query {
             return true;
         }
 
-        public QueryResult Search(CatalogManager manager) {
+        public QueryResult Search(CatalogManager manager)
+        {
             List<Uri> catalogs = new(manager.Catalogs());
             while (catalogs.Count > 0) {
                 Uri uri = catalogs[0];

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Catalog/Query/QueryEntity.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Catalog/Query/QueryEntity.cs
@@ -6,7 +6,8 @@ namespace Org.XmlResolver.Catalog.Query {
         public readonly string SystemId;
         public readonly string PublicId;
 
-        public QueryEntity(string entityName, string systemId, string publicId) : base() {
+        public QueryEntity(string entityName, string systemId, string publicId) : base()
+        {
             EntityName = entityName;
             SystemId = systemId;
             PublicId = publicId;

--- a/XmlResolver/XmlResolver/Org/XmlResolver/CatalogManager.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/CatalogManager.cs
@@ -80,7 +80,8 @@ namespace Org.XmlResolver {
         /// <returns>The list of catalog files, as absolute URIs.</returns>
         public List<Uri> Catalogs() {
             List<Uri> catlist = new();
-            foreach (var cat in (List<string>) _resolverConfiguration.GetFeature(ResolverFeature.CATALOG_FILES)) {
+            foreach (var cat in (List<string>) _resolverConfiguration.GetFeature(ResolverFeature.CATALOG_FILES))
+            {
                 catlist.Add(new Uri(UriUtils.Cwd(), cat));
             }
             return catlist;
@@ -219,7 +220,8 @@ namespace Org.XmlResolver {
         {
             systemId = fixWindowsSystemIdentifier(systemId);
             ExternalIdentifiers external = NormalizeExternalIdentifiers(systemId, publicId);
-            return new QueryEntity(entityName, external.SystemId, external.PublicId).Search(this).ResultUri();
+            QueryResult result = new QueryEntity(entityName, external.SystemId, external.PublicId).Search(this);
+            return result.ResultUri();
         }
 
         /// <summary>

--- a/XmlResolver/XmlResolver/Org/XmlResolver/CatalogResolver.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/CatalogResolver.cs
@@ -30,7 +30,8 @@ namespace Org.XmlResolver {
         /// Create a new resolver using the specified configuration.
         /// </summary>
         /// <param name="config">The resolver configuration.</param>
-        public CatalogResolver(XmlResolverConfiguration config) {
+        public CatalogResolver(XmlResolverConfiguration config)
+        {
             this.config = config;
         }
 
@@ -253,7 +254,8 @@ namespace Org.XmlResolver {
             }
             if (resolved != null) {
                 result = Resource(systemId, resolved, cache.CachedSystem(resolved, publicId));
-            } else {
+            } else
+            {
                 if (systemId != null) {
                     absSystem = new Uri(systemId);
                 }

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Resolver.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Resolver.cs
@@ -73,7 +73,8 @@ namespace Org.XmlResolver {
         /// <param name="role">The role, which is ignored.</param>
         /// <param name="ofObjectToReturn">The type of object to return, which is ignored.</param>
         /// <returns>A stream if the resource was located or null otherwise.</returns>
-        public override object? GetEntity(Uri absoluteUri, string? role, Type? ofObjectToReturn) {
+        public override object? GetEntity(Uri absoluteUri, string? role, Type? ofObjectToReturn)
+        {
             ResolvedResource rsrc = _resolver.ResolveEntity(null, null, absoluteUri.ToString(), null);
             if (rsrc == null) {
                 try {
@@ -139,7 +140,8 @@ namespace Org.XmlResolver {
         /// <param name="relativeUri">The relative URI.</param>
         /// <returns>The resolved absolute URI or null.</returns>
         /// <exception cref="NotSupportedException">If resolution produces a relative URI</exception>
-        public override Uri ResolveUri(Uri? baseUri, string? relativeUri) {
+        public override Uri ResolveUri(Uri? baseUri, string? relativeUri)
+        {
             // There's a horrible bug in System.Xml where it attempts to resolve public identifiers
             // as if they were relative URIs. It turns them into things like this:
             //    http://example.com/path/-//DTD//Example 1.0//EN
@@ -181,6 +183,7 @@ namespace Org.XmlResolver {
             }
             
             if (publicId) {
+                // The API doesn't expect null to be returned, but I'm not sure what else to do...
                 return null;
             }
 

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Resolver.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Resolver.cs
@@ -17,7 +17,8 @@ namespace Org.XmlResolver {
         /// <summary>
         /// Creates a new resolver with a default configuration.
         /// </summary>
-        public Resolver() {
+        public Resolver()
+        {
             _resolver = new CatalogResolver();
         }
 

--- a/XmlResolver/XmlResolver/Org/XmlResolver/ResolverLogger.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/ResolverLogger.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Text;
 using NLog;
 

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Tools/ResolvingXmlReader.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Tools/ResolvingXmlReader.cs
@@ -178,7 +178,7 @@ namespace Org.XmlResolver.Tools {
         }
 
         public override int AttributeCount => _reader.AttributeCount;
-        public override string? BaseURI => _reader.BaseURI;
+        public override string BaseURI => _reader.BaseURI;
         public override int Depth => _reader.Depth;
         public override bool EOF => _reader.EOF;
         public override bool IsEmptyElement => _reader.IsEmptyElement;

--- a/XmlResolver/XmlResolver/Org/XmlResolver/Utils/UriUtils.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/Utils/UriUtils.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Compression;
 using System.IO.Packaging;
 using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -19,6 +20,8 @@ namespace Org.XmlResolver.Utils {
     /// that may arise (because resources aren't found, for example, or aren't accessible.</para>
     /// 
     public class UriUtils {
+        protected static HttpClient httpClient = new HttpClient();
+
         /// <summary>
         /// Report if the platform is Windows.
         /// </summary>
@@ -359,10 +362,9 @@ namespace Org.XmlResolver.Utils {
         }
         
         private static Stream _getHttpStream(string uri) {
-            using (WebClient client = new WebClient()) {
-                byte[] response = client.DownloadData(uri);
-                return new MemoryStream(response);
-            }
+            HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, uri);
+            HttpResponseMessage resp = httpClient.Send(req);
+            return resp.Content.ReadAsStream();
         }
         
         private static Stream _getPackStream(string uri, Assembly asm) {

--- a/XmlResolver/XmlResolver/XmlResolver.csproj
+++ b/XmlResolver/XmlResolver/XmlResolver.csproj
@@ -2,12 +2,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Norman Walsh</Authors>
     <Description>The xmlresolver project provides an implementation of the System.Xml.XmlResolver. It uses the OASIS XML Catalogs V1.1 Standard to provide a mapping from external identifiers and URIs to local resources.</Description>
     <PackageTags>XML,XmlResolver</PackageTags>
-    <Copyright>Copyright © 2021, 2022 Norman Walsh. Portions Copyright © 2021, 2022 Saxonica, Ltd.</Copyright>
+    <Copyright>Copyright © 2021-2023 Norman Walsh. Portions Copyright © 202-2023 Saxonica, Ltd.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://xmlresolver.org/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/xmlresolver/xmlresolvercs</RepositoryUrl>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-resolverVersion=1.5.1
+resolverVersion=2.0.0


### PR DESCRIPTION
1. Fix #59 by loading assemblies by name rather than searching for them by location
2. Fix #60 by upgrading to .NET 6
3. Fix #61 by converting from the WebClient class to the HttpClient instead.

Searching for assemblies by name rather than location is a backwards incompatible change in that the string used to identify a catalog in an assembly is now the AssemblyName rather than the name of the DLL

Upgrading to HttpClient has changed the type of the status code property of the `StatusCode` in the `ResourceConnection` class.
