### PR TITLE
Fix the bug where UriUtils.GetStream() hides http errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ if (!hasProperty("nugetSource")) {
 tasks.register("dotnetBuild") {
   inputs.files fileTree(dir: "${projectDir}/XmlResolver/XmlResolver")
   outputs.file "${projectDir}/XmlResolver/XmlResolver/bin/Release/net5.0/XmlResolver.dll"
-  outputs.file "${projectDir}/XmlResolver/XmlResolver/bin/Release/XmlResolver.{$resolverVersion}.nupkg"
+  outputs.file "${projectDir}/XmlResolver/XmlResolver/bin/Release/XmlResolver.${resolverVersion}.nupkg"
 
   doLast {
     exec {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-resolverVersion=2.0.0
+resolverVersion=2.1.0


### PR DESCRIPTION
As proposed in the bug, non-200 responses now throw an exception. This is only intended as a convenience method. If you need more sophisticated semantics, this is not the API for you.