### PR TITLE
Bug fixes

### DIFF
--- a/XmlResolver/XmlResolver.cs
+++ b/XmlResolver/XmlResolver.cs
@@ -338,7 +338,7 @@ public class XmlResolver
         {
             if (lookup.IsResolved)
             {
-                lookup = _rddlLookup(lookup);
+                lookup = _rddlLookup(lookup, lookup.ResolvedUri);
             }
             else
             {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-resolverVersion=6.0.0
+resolverVersion=6.0.2


### PR DESCRIPTION
1. Search for RDDL in the *resolved* URI (if the resource was resolved in the catalog)

Bumped the version to 6.0.2 for parity with an equivalent fix in the Java version.