### PR TITLE
Update the legacy V2 release

### DIFF
--- a/XmlResolver/SampleApp/SampleApp.csproj
+++ b/XmlResolver/SampleApp/SampleApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
@@ -16,9 +16,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="NuGet.Frameworks" Version="5.10.0" />
-      <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
-      <PackageReference Include="XmlResolverData" Version="1.1.0" />
+      <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
+      <PackageReference Include="XmlResolverData" Version="1.2.4" />
 
     </ItemGroup>
 

--- a/XmlResolver/UnitTests/CMNextTest.cs
+++ b/XmlResolver/UnitTests/CMNextTest.cs
@@ -26,101 +26,101 @@ namespace UnitTests {
         public void NextTest1() {
             Uri expected = UriUtils.Resolve(baseUri, "public.dtd");
             Uri result = manager.LookupPublic("http://example.com/system-next.dtd", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void nextTest2() {
+        public void NextTest2() {
             // no next required
             Uri expected = UriUtils.Resolve(baseUri, "system.dtd");
             Uri result = manager.LookupPublic("http://example.com/system.dtd", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void nextTest3() {
+        public void NextTest3() {
             Uri expected = UriUtils.Resolve(baseUri, "system-next.dtd");
             Uri result = manager.LookupSystem("http://example.com/system-next.dtd");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void nextTest4() {
+        public void NextTest4() {
             Uri expected = UriUtils.Resolve(baseUri, "system-next.dtd");
             Uri result = manager.LookupPublic("http://example.com/system-next.dtd", "-//EXAMPLE//DTD Example Next//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void nextTest5() {
+        public void NextTest5() {
             Uri expected = UriUtils.Resolve(baseUri, "public-next.dtd");
             Uri result = manager.LookupPublic("http://example.com/miss.dtd", "-//EXAMPLE//DTD Example Next//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void nextTest6() {
+        public void NextTest6() {
             Uri expected = UriUtils.Resolve(baseUri, "found-in-one.xml");
             Uri result = manager.LookupUri("http://example.com/document.xml");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void nextTest7() {
+        public void NextTest7() {
             // After looking in the next catalogs, continue in the following catalogs
             Uri result = manager.LookupSystem("http://example.com/found-in-following.dtd");
-            Assert.NotNull(result);
-            Assert.True(result.ToString().EndsWith("cm/following.dtd"));
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.ToString().EndsWith("cm/following.dtd"), Is.EqualTo(true));
         }
 
         [Test]
-        public void nextTest8() {
+        public void NextTest8() {
             // After looking in the delegated catalogs, do not return to the following catalogs
             Uri result = manager.LookupSystem("http://example.com/delegated/but/not/found/in/delegated/catalogs.dtd");
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void delegateSystemTest1() {
+        public void DelegateSystemTest1() {
             Uri expected = UriUtils.Resolve(baseUri, "delegated-to-one.dtd");
             Uri result = manager.LookupSystem("http://example.com/delegated/one/system.dtd");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void delegateSystemTest2() {
+        public void DelegateSystemTest2() {
             Uri expected = UriUtils.Resolve(baseUri, "delegated-to-two.dtd");
             Uri result = manager.LookupSystem("http://example.com/delegated/two/system.dtd");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void delegateSystemTest3() {
+        public void DelegateSystemTest3() {
             Uri expected = UriUtils.Resolve(baseUri, "three-from-two.dtd");
             Uri result = manager.LookupSystem("http://example.com/delegated/three/system.dtd");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void delegateSystemTest4() {
+        public void DelegateSystemTest4() {
             Uri expected = UriUtils.Resolve(baseUri, "test-from-two.dtd");
             Uri result = manager.LookupSystem("http://example.com/delegated/one/test/system.dtd");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void delegateSystemTest5() {
+        public void DelegateSystemTest5() {
             // This Uri is in nextone.xml, but because nextroot.xml delegates to different catalogs,
             // it's never seen by the resolver.
             Uri result = manager.LookupSystem("http://example.com/delegated/four/system.dtd");
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void delegateSystemTest6() {
+        public void DelegateSystemTest6() {
             Uri expected = UriUtils.Resolve(baseUri, "five-from-two.dtd");
             Uri result = manager.LookupSystem("http://example.com/delegated/five/system.dtd");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
     }
 }

--- a/XmlResolver/UnitTests/CMPreferTest.cs
+++ b/XmlResolver/UnitTests/CMPreferTest.cs
@@ -18,38 +18,38 @@ namespace UnitTests {
         }
         
         [Test]
-        public void publicTest1() {
+        public void PublicTest1() {
             Uri expected = UriUtils.Resolve(baseUri, "prefer-public.dtd");
             Uri result = manager.LookupPublic("http://example.com/miss", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
         
         [Test]
-        public void publicTest2() {
+        public void PublicTest2() {
             Uri expected = UriUtils.Resolve(baseUri, "system.dtd");
             Uri result = manager.LookupPublic("http://example.com/system.dtd", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void publicTest3() {
+        public void PublicTest3() {
             Uri expected = UriUtils.Resolve(baseUri, "prefer-system.dtd");
             Uri result = manager.LookupNotation("irrelevant", null, "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void publicTest4() {
+        public void PublicTest4() {
             Uri expected = UriUtils.Resolve(baseUri, "prefer-system.dtd");
             Uri result = manager.LookupPublic(PublicId.EncodeUrn("-//EXAMPLE//DTD Example//EN").ToString(), null);
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void publicTest5() {
+        public void PublicTest5() {
             Uri expected = UriUtils.Resolve(baseUri, "prefer-system.dtd");
             Uri result = manager.LookupPublic(PublicId.EncodeUrn("-//EXAMPLE//DTD Different//EN").ToString(), "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
     }
 }

--- a/XmlResolver/UnitTests/CMSimpleTest.cs
+++ b/XmlResolver/UnitTests/CMSimpleTest.cs
@@ -18,171 +18,171 @@ namespace UnitTests {
         }
 
         [Test]
-        public void publicTest1() {
+        public void PublicTest1() {
             Uri expected = UriUtils.Resolve(baseUri, "public.dtd");
             Uri result = manager.LookupPublic("http://example.com/miss", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void publicTest2() {
+        public void PublicTest2() {
             Uri expected = UriUtils.Resolve(baseUri, "system.dtd");
             Uri result = manager.LookupPublic("http://example.com/system.dtd", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void systemTest() {
+        public void SystemTest() {
             Uri expected = UriUtils.Resolve(baseUri, "system.dtd");
             Uri result = manager.LookupSystem("http://example.com/system.dtd");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void rewriteSystemTest() {
+        public void RewriteSystemTest() {
             Uri expected = UriUtils.Resolve(baseUri, "local/path/system.dtd");
             Uri result = manager.LookupSystem("http://example.com/rewrite/path/system.dtd");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void systemSuffixTest1() {
+        public void SystemSuffixTest1() {
             Uri expected = UriUtils.Resolve(baseUri, "suffix/base-long.dtd");
             Uri result = manager.LookupSystem("http://example.com/path/base.dtd");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void systemSuffixTest2() {
+        public void SystemSuffixTest2() {
             Uri expected = UriUtils.Resolve(baseUri, "suffix/base-short.dtd");
             Uri result = manager.LookupSystem("http://example.com/alternate/base.dtd");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void uriTest1() {
+        public void UriTest1() {
             Uri expected = UriUtils.Resolve(baseUri, "/path/document.xml");
             Uri result = manager.LookupUri("http://example.com/document.xml");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void uriTest2() {
+        public void UriTest2() {
             Uri expected = UriUtils.Resolve(baseUri, "/path/rddl.xml");
             Uri result = manager.LookupUri("http://example.com/rddl.xml");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void uriTest3() {
+        public void UriTest3() {
             Uri expected = UriUtils.Resolve(baseUri, "/path/rddl.xml");
             Uri result = manager.LookupNamespaceUri("http://example.com/rddl.xml",
                 "nature", "purpose");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void uriTest4() {
+        public void UriTest4() {
             Uri result = manager.LookupNamespaceUri("http://example.com/rddl.xml",
                 "not-nature", "not-purpose");
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void rewriteUriTest() {
+        public void RewriteUriTest() {
             Uri expected = UriUtils.Resolve(baseUri, "/path/local/docs/document.xml");
             Uri result = manager.LookupUri("http://example.com/rewrite/docs/document.xml");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void uriSuffixTest1() {
+        public void UriSuffixTest1() {
             Uri expected = UriUtils.Resolve(baseUri, "suffix/base-long.xml");
             Uri result = manager.LookupUri("http://example.com/path/base.xml");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void uriSuffixTest2() {
+        public void UriSuffixTest2() {
             Uri expected = UriUtils.Resolve(baseUri, "suffix/base-short.xml");
             Uri result = manager.LookupUri("http://example.com/alternate/base.xml");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void bookTest1() {
+        public void BookTest1() {
             Uri expected = UriUtils.Resolve(baseUri, "path/docbook.dtd");
             Uri result = manager.LookupDoctype("book", null, null);
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void bookTest2() {
+        public void BookTest2() {
             Uri expected = UriUtils.Resolve(baseUri, "system.dtd");
             Uri result = manager.LookupDoctype("book",
                 "http://example.com/system.dtd", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void bookTest3() {
+        public void BookTest3() {
             Uri expected = UriUtils.Resolve(baseUri, "public.dtd");
             Uri result = manager.LookupDoctype("book",
                 "http://example.com/miss.dtd", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void documentTest() {
+        public void DocumentTest() {
             Uri expected = UriUtils.Resolve(baseUri, "path/default.xml");
             Uri result = manager.LookupDocument();
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void entityTest1() {
+        public void EntityTest1() {
             Uri expected = UriUtils.Resolve(baseUri, "chap01.xml");
             Uri result = manager.LookupEntity("chap01", null, null);
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void entityTest2() {
+        public void EntityTest2() {
             Uri expected = UriUtils.Resolve(baseUri, "system.dtd");
             Uri result = manager.LookupEntity("chap01",
                 "http://example.com/system.dtd", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void entityTest3() {
+        public void EntityTest3() {
             Uri expected = UriUtils.Resolve(baseUri, "public.dtd");
             Uri result = manager.LookupEntity("chap01",
                 "http://example.com/miss.dtd", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void notationTest1() {
+        public void NotationTest1() {
             Uri expected = UriUtils.Resolve(baseUri, "notation.xml");
             Uri result = manager.LookupNotation("notename", null, null);
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void notationTest2() {
+        public void NotationTest2() {
             Uri expected = UriUtils.Resolve(baseUri, "system.dtd");
             Uri result = manager.LookupNotation("notename",
                 "http://example.com/system.dtd", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void notationTest3() {
+        public void NotationTest3() {
             Uri expected = UriUtils.Resolve(baseUri, "public.dtd");
             Uri result = manager.LookupNotation("notename",
                 "http://example.com/miss.dtd", "-//EXAMPLE//DTD Example//EN");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
     }
 }

--- a/XmlResolver/UnitTests/CacheSubclassTest.cs
+++ b/XmlResolver/UnitTests/CacheSubclassTest.cs
@@ -15,11 +15,11 @@ namespace UnitTests {
         [Test]
         public void TestFeatureCache() {
             // Test that a subclass of ResourceCache can be used as a ResourceCache.
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.CACHE));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.CACHE), Is.EqualTo(true));
             CacheSubclass myCache = new CacheSubclass(config);
             ResourceCache orig = (ResourceCache)config.GetFeature(ResolverFeature.CACHE);
             config.SetFeature(ResolverFeature.CACHE, myCache);
-            Assert.AreSame(myCache, config.GetFeature(ResolverFeature.CACHE));
+            Assert.That(myCache, Is.SameAs(config.GetFeature(ResolverFeature.CACHE)));
             config.SetFeature(ResolverFeature.CACHE, orig);
         }
 

--- a/XmlResolver/UnitTests/CacheTest.cs
+++ b/XmlResolver/UnitTests/CacheTest.cs
@@ -33,47 +33,47 @@ namespace UnitTests {
 
         [Test]
         public void DefaultInfo() {
-            Assert.NotNull(cache.GetCacheInfo("^file:"));
-            Assert.NotNull(cache.GetCacheInfo("^jar:file:"));
-            Assert.NotNull(cache.GetCacheInfo("^classpath:"));
-            Assert.NotNull(cache.GetCacheInfo("^pack:"));
-            Assert.Null(cache.GetCacheInfo("^fribble:"));
-            Assert.AreEqual(4, cache.GetCacheInfoList().Count);
+            Assert.That(cache.GetCacheInfo("^file:"), Is.Not.Null);
+            Assert.That(cache.GetCacheInfo("^jar:file:"), Is.Not.Null);
+            Assert.That(cache.GetCacheInfo("^classpath:"), Is.Not.Null);
+            Assert.That(cache.GetCacheInfo("^pack:"), Is.Not.Null);
+            Assert.That(cache.GetCacheInfo("^fribble:"), Is.Null);
+            Assert.That(cache.GetCacheInfoList().Count, Is.EqualTo(4));
          }
 
         [Test]
         public void AddCacheInfoDefault() {
             cache.AddCacheInfo("^fribble:", true);
-            Assert.AreEqual(5, cache.GetCacheInfoList().Count);
+            Assert.That(cache.GetCacheInfoList().Count, Is.EqualTo(5));
             CacheInfo info = cache.GetCacheInfo("^fribble:");
-            Assert.AreEqual("^fribble:", info.UriPattern.ToString());
-            Assert.AreEqual(ResourceCache.CacheSize, info.CacheSize);
-            Assert.AreEqual(ResourceCache.CacheSpace, info.CacheSpace);
-            Assert.AreEqual(ResourceCache.DeleteWait, info.DeleteWait);
-            Assert.AreEqual(ResourceCache.MaxAge, info.MaxAge);
+            Assert.That(info.UriPattern.ToString(), Is.EqualTo("^fribble:"));
+            Assert.That(info.CacheSize, Is.EqualTo(ResourceCache.CacheSize));
+            Assert.That(info.CacheSpace, Is.EqualTo(ResourceCache.CacheSpace));
+            Assert.That(info.DeleteWait, Is.EqualTo(ResourceCache.DeleteWait));
+            Assert.That(info.MaxAge, Is.EqualTo(ResourceCache.MaxAge));
             cache.RemoveCacheInfo("^fribble:");
-            Assert.AreEqual(4, cache.GetCacheInfoList().Count);
-            Assert.Null(cache.GetCacheInfo("^fribble:"));
+            Assert.That(cache.GetCacheInfoList().Count, Is.EqualTo(4));
+            Assert.That(cache.GetCacheInfo("^fribble:"), Is.Null);
         }
 
         [Test]
         public void AddCacheInfoExplicit() {
             cache.AddCacheInfo("^fribble:", true);
             cache.AddCacheInfo("^frabble:", false, 123, 456, 789, 10);
-            Assert.AreEqual(6, cache.GetCacheInfoList().Count);
+            Assert.That(cache.GetCacheInfoList().Count, Is.EqualTo(6));
             CacheInfo info = cache.GetCacheInfo("^frabble:");
-            Assert.AreEqual("^frabble:", info.UriPattern.ToString());
-            Assert.AreEqual(456, info.CacheSize);
-            Assert.AreEqual(789, info.CacheSpace);
-            Assert.AreEqual(123, info.DeleteWait);
-            Assert.AreEqual(10, info.MaxAge);
+            Assert.That(info.UriPattern.ToString(), Is.EqualTo("^frabble:"));
+            Assert.That(info.CacheSize, Is.EqualTo(456));
+            Assert.That(info.CacheSpace, Is.EqualTo(789));
+            Assert.That(info.DeleteWait, Is.EqualTo(123));
+            Assert.That(info.MaxAge, Is.EqualTo(10));
             cache.RemoveCacheInfo("^frabble:");
-            Assert.AreEqual(5, cache.GetCacheInfoList().Count);
-            Assert.Null(cache.GetCacheInfo("^frabble:"));
-            Assert.NotNull(cache.GetCacheInfo("^fribble:"));
+            Assert.That(cache.GetCacheInfoList().Count, Is.EqualTo(5));
+            Assert.That(cache.GetCacheInfo("^frabble:"), Is.Null);
+            Assert.That(cache.GetCacheInfo("^fribble:"), Is.Not.Null);
             cache.RemoveCacheInfo("^fribble:");
-            Assert.AreEqual(4, cache.GetCacheInfoList().Count);
-            Assert.Null(cache.GetCacheInfo("^fribble:"));
+            Assert.That(cache.GetCacheInfoList().Count, Is.EqualTo(4));
+            Assert.That(cache.GetCacheInfo("^fribble:"), Is.Null);
         }
 
         [Test]
@@ -87,20 +87,20 @@ namespace UnitTests {
             secondConfig.SetFeature(ResolverFeature.CACHE_ENABLED, true);
             ResourceCache secondCache = new ResourceCache(secondConfig);
 
-            Assert.AreEqual(6, secondCache.GetCacheInfoList().Count);
+            Assert.That(secondCache.GetCacheInfoList().Count, Is.EqualTo(6));
             CacheInfo info = secondCache.GetCacheInfo("^frabble:");
-            Assert.AreEqual("^frabble:", info.UriPattern.ToString());
-            Assert.AreEqual(456, info.CacheSize);
-            Assert.AreEqual(789, info.CacheSpace);
-            Assert.AreEqual(123, info.DeleteWait);
-            Assert.AreEqual(10, info.MaxAge);
+            Assert.That(info.UriPattern.ToString(), Is.EqualTo("^frabble:"));
+            Assert.That(info.CacheSize, Is.EqualTo(456));
+            Assert.That(info.CacheSpace, Is.EqualTo(789));
+            Assert.That(info.DeleteWait, Is.EqualTo(123));
+            Assert.That(info.MaxAge, Is.EqualTo(10));
             secondCache.RemoveCacheInfo("^frabble:");
-            Assert.AreEqual(5, secondCache.GetCacheInfoList().Count);
-            Assert.Null(secondCache.GetCacheInfo("^frabble:"));
-            Assert.NotNull(secondCache.GetCacheInfo("^fribble:"));
+            Assert.That(secondCache.GetCacheInfoList().Count, Is.EqualTo(5));
+            Assert.That(secondCache.GetCacheInfo("^frabble:"), Is.Null);
+            Assert.That(secondCache.GetCacheInfo("^fribble:"), Is.Not.Null);
             secondCache.RemoveCacheInfo("^fribble:");
-            Assert.AreEqual(4, secondCache.GetCacheInfoList().Count);
-            Assert.Null(secondCache.GetCacheInfo("^fribble:"));
+            Assert.That(secondCache.GetCacheInfoList().Count, Is.EqualTo(4));
+            Assert.That(secondCache.GetCacheInfo("^fribble:"), Is.Null);
         }
 
         [Test]
@@ -109,15 +109,15 @@ namespace UnitTests {
             cache.AddCacheInfo("^frabble:", false, 123, 456, 789, 10);
             cache.AddCacheInfo("\\.dtd$", false);
 
-            Assert.True(cache.CacheUri("http://example.com"));
-            Assert.True(cache.CacheUri("fribble://example.com"));
-            Assert.False(cache.CacheUri("frabble://example.com"));
-            Assert.False(cache.CacheUri("file:///foo"));
-            Assert.False(cache.CacheUri("jar:file:///foo"));
-            Assert.False(cache.CacheUri("classpath:whatever"));
+            Assert.That(cache.CacheUri("http://example.com"), Is.EqualTo(true));
+            Assert.That(cache.CacheUri("fribble://example.com"), Is.EqualTo(true));
+            Assert.That(cache.CacheUri("frabble://example.com"), Is.EqualTo(false));
+            Assert.That(cache.CacheUri("file:///foo"), Is.EqualTo(false));
+            Assert.That(cache.CacheUri("jar:file:///foo"), Is.EqualTo(false));
+            Assert.That(cache.CacheUri("classpath:whatever"), Is.EqualTo(false));
 
-            Assert.True(cache.CacheUri("jar:http://example.com"));
-            Assert.False(cache.CacheUri("http://examle.com/path/to/some.dtd"));
+            Assert.That(cache.CacheUri("jar:http://example.com"), Is.EqualTo(true));
+            Assert.That(cache.CacheUri("http://examle.com/path/to/some.dtd"), Is.EqualTo(false));
 
             cache.RemoveCacheInfo("^fribble:");
             cache.RemoveCacheInfo("^frabble:");
@@ -128,7 +128,7 @@ namespace UnitTests {
         public void TestCacheData() {
             try {
                 ResolvedResource rsrc = cresolver.ResolveUri("http://localhost:8222/docs/sample/xlink.xsd", null);
-                Assert.NotNull(rsrc.GetInputStream());
+                Assert.That(rsrc.GetInputStream(), Is.Not.Null);
                 rsrc.GetInputStream().Close();
             } catch (Exception ex) {
                 Console.WriteLine(ex.Message);
@@ -142,22 +142,22 @@ namespace UnitTests {
             localConfig.SetFeature(ResolverFeature.CACHE_DIRECTORY, "/tmp/cache");
             localConfig.SetFeature(ResolverFeature.CACHE_ENABLED, false);
             ResourceCache localCache = new ResourceCache(localConfig);
-            Assert.Null(localCache.GetDirectory());
-            Assert.False(localCache.CacheUri("http://example.com/test.dtd"));
+            Assert.That(localCache.GetDirectory(), Is.Null);
+            Assert.That(localCache.CacheUri("http://example.com/test.dtd"), Is.EqualTo(false));
         }
 
         [Test]
         public void TestCacheDisabledAfterInitialization()
         {
             XmlResolverConfiguration localConfig = new XmlResolverConfiguration();
-            Assert.False((bool) localConfig.GetFeature(ResolverFeature.CACHE_ENABLED));
+            Assert.That((bool) localConfig.GetFeature(ResolverFeature.CACHE_ENABLED), Is.EqualTo(false));
 
             CatalogResolver resolver = new CatalogResolver(localConfig);
             resolver.GetConfiguration().SetFeature(ResolverFeature.CACHE_ENABLED, false);
 
             // With the cache disabled, we get back null
             ResolvedResource result = resolver.ResolveUri("https://jats.nlm.nih.gov/publishing/1.3/JATS-journalpublishing1-3.dtd", null);
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
         
     }

--- a/XmlResolver/UnitTests/CatalogLookupTest.cs
+++ b/XmlResolver/UnitTests/CatalogLookupTest.cs
@@ -40,15 +40,15 @@ namespace UnitTests {
         }
 
         [Test]
-        public void lookupSystem() {
+        public void LookupSystem() {
             Uri result = manager.LookupSystem("https://example.com/sample/1.0/sample.dtd");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd")));
         }
 
         [Test]
-        public void lookupSystemMiss() {
+        public void LookupSystemMiss() {
             Uri result = manager.LookupSystem("https://xmlresolver.org/ns/sample/sample.rng");
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         // ============================================================
@@ -56,240 +56,234 @@ namespace UnitTests {
         // Note that the N/A entries in column three are a bit misleading.
 
         [Test]
-        public void lookupPublic_prefer_public_nosystem_public1() {
+        public void LookupPublic_prefer_public_nosystem_public1() {
             // Catalog contains a matching public entry, but not a matching system entry
             Uri result = manager.LookupPublic(null, "-//Sample//DTD Sample 1.0//EN");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-public.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-public.dtd")));
         }
 
         [Test]
-        public void lookupPublic_prefer_public_nosystem_public2() {
+        public void LookupPublic_prefer_public_nosystem_public2() {
             // Catalog contains a matching system entry, but not a matching public entry
-            Assert.True(true); // N/A
         }
 
         [Test]
-        public void lookupPublic_prefer_public_nosystem_public3() {
+        public void LookupPublic_prefer_public_nosystem_public3() {
             // Catalog contains both a matching system entry and a matching public entry
-            Assert.True(true); // N/A
         }
 
         [Test]
-        public void lookupPublic_prefer_public_system_nopublic1() {
+        public void LookupPublic_prefer_public_system_nopublic1() {
             // Catalog contains a matching public entry, but not a matching system entry
-            Assert.True(true); // N/A
         }
 
         [Test]
-        public void lookupPublic_prefer_public_system_nopublic2() {
+        public void LookupPublic_prefer_public_system_nopublic2() {
             // Catalog contains a matching system entry, but not a matching public entry
             Uri result = manager.LookupPublic("https://example.com/sample/1.0/sample.dtd", null);
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd")));
         }
 
 
         [Test]
-        public void lookupPublic_prefer_public_system_nopublic3() {
+        public void LookupPublic_prefer_public_system_nopublic3() {
             // Catalog contains both a matching system entry and a matching public entry
             Uri result = manager.LookupPublic("https://example.com/sample/1.0/sample.dtd", null);
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd")));
         }
 
         [Test]
-        public void lookupPublic_prefer_public_system_public1() {
+        public void LookupPublic_prefer_public_system_public1() {
             // Catalog contains a matching public entry, but not a matching system entry
             Uri result = manager.LookupPublic("https://example.com/not-sample/1.0/sample.dtd",
                 "-//Sample//DTD Sample 1.0//EN");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-public.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-public.dtd")));
         }
 
         [Test]
-        public void lookupPublic_prefer_public_system_public2() {
+        public void LookupPublic_prefer_public_system_public2() {
             // Catalog contains a matching system entry, but not a matching public entry
             Uri result = manager.LookupPublic("https://example.com/sample/1.0/sample.dtd",
                 "-//Sample//DTD Not Sample 1.0//EN");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd")));
         }
 
         [Test]
-        public void lookupPublic_prefer_public_system_public3() {
+        public void LookupPublic_prefer_public_system_public3() {
             // Catalog contains both a matching system entry and a matching public entry
             Uri result = manager.LookupPublic("https://example.com/sample/1.0/sample.dtd",
                 "-//Sample//DTD Sample 1.0//EN");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd")));
         }
 
         [Test]
-        public void lookupPublic_prefer_system_nosystem_public1() {
+        public void LookupPublic_prefer_system_nosystem_public1() {
             // Catalog contains a matching public entry, but not a matching system entry
             Uri result = manager.LookupPublic(null, "-//Sample//DTD Sample 1.0//EN");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-public.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-public.dtd")));
         }
 
         [Test]
-        public void lookupPublic_prefer_system_nosystem_public2() {
+        public void LookupPublic_prefer_system_nosystem_public2() {
             // Catalog contains a matching system entry, but not a matching public entry
-            Assert.True(true); // N/A
         }
 
         [Test]
-        public void lookupPublic_prefer_system_nosystem_public3() {
+        public void LookupPublic_prefer_system_nosystem_public3() {
             // Catalog contains both a matching system entry and a matching public entry
-            Assert.True(true); // N/A
         }
 
         [Test]
-        public void lookupPublic_prefer_system_system_nopublic1() {
+        public void LookupPublic_prefer_system_system_nopublic1() {
             // Catalog contains a matching public entry, but not a matching system entry
-            Assert.True(true); // N/A
         }
 
         [Test]
-        public void lookupPublic_prefer_system_system_nopublic2() {
+        public void LookupPublic_prefer_system_system_nopublic2() {
             // Catalog contains a matching system entry, but not a matching public entry
             Uri result = manager.LookupPublic("https://example.com/sample/1.0/sample.dtd", null);
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd")));
         }
 
         [Test]
-        public void lookupPublic_prefer_system_system_nopublic3() {
+        public void LookupPublic_prefer_system_system_nopublic3() {
             // Catalog contains both a matching system entry and a matching public entry
             Uri result = manager.LookupPublic("https://example.com/sample/1.0/sample.dtd", null);
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd")));
         }
 
         [Test]
-        public void lookupPublic_prefer_system_system_public1() {
+        public void LookupPublic_prefer_system_system_public1() {
             // Catalog contains a matching public entry, but not a matching system entry
             Uri result = manager.LookupPublic("https://example.com/not-sample/1.0/sample.dtd",
                 "-//Sample//DTD Prefer Sample 1.0//EN");
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void lookupPublic_prefer_system_system_public2() {
+        public void LookupPublic_prefer_system_system_public2() {
             // Catalog contains a matching system entry, but not a matching public entry
             Uri result = manager.LookupPublic("https://example.com/sample/1.0/sample.dtd",
                 "-//Sample//DTD Not Sample 1.0//EN");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd")));
         }
 
         [Test]
-        public void lookupPublic_prefer_system_system_public3() {
+        public void LookupPublic_prefer_system_system_public3() {
             // Catalog contains both a matching system entry and a matching public entry
             Uri result = manager.LookupPublic("https://example.com/sample/1.0/sample.dtd",
                 "-//Sample//DTD Prefer Sample 1.0//EN");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-system.dtd")));
         }
 
         // ============================================================
 
         [Test]
-        public void rewriteSystem() {
+        public void RewriteSystem() {
             Uri result = manager.LookupSystem("https://example.com/path1/sample/3.0/sample.dtd");
             Uri expected = new Uri("https://example.com/path2/sample/3.0/sample.dtd");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void systemSuffix() {
+        public void SystemSuffix() {
             Uri result = manager.LookupSystem("https://example.com/whatever/you/want/suffix.dtd");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample20/sample-suffix.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample20/sample-suffix.dtd")));
         }
 
         [Test]
-        public void delegatePublicLong() {
+        public void DelegatePublicLong() {
             Uri result = manager.LookupPublic(null, "-//Sample Delegated//DTD Sample 1.0//EN");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-delegated.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-delegated.dtd")));
         }
 
         [Test]
-        public void delegatePublicShort() {
+        public void DelegatePublicShort() {
             Uri result = manager.LookupPublic(null, "-//Sample Delegated//DTD Sample 2.0//EN");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample20/sample-shorter.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample20/sample-shorter.dtd")));
         }
 
         [Test]
-        public void delegatePublicFail() {
+        public void DelegatePublicFail() {
             Uri result = manager.LookupPublic(null, "-//Sample Delegated//DTD Sample 3.0//EN");
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void delegateSystemLong() {
+        public void DelegateSystemLong() {
             Uri result = manager.LookupPublic("https://example.com/delegated/sample/1.0/sample.dtd", null);
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-delegated.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-delegated.dtd")));
         }
 
         [Test]
-        public void delegateSystemShort() {
+        public void DelegateSystemShort() {
             Uri result = manager.LookupPublic("https://example.com/delegated/sample/2.0/sample.dtd", null);
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample20/sample-shorter.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample20/sample-shorter.dtd")));
         }
 
         [Test]
-        public void delegateSystemFail() {
+        public void DelegateSystemFail() {
             Uri result = manager.LookupPublic("https://example.com/delegated/sample/3.0/sample.dtd", null);
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         /*
         [Test]
-        public void undelegated() {
+        public void Undelegated() {
             // If there aren't any delegate entries, the entries in lookup2.xml really do match.
             XMLResolverConfiguration uconfig = new XMLResolverConfiguration(Collections.emptyList(), Collections.emptyList());
             uconfig.setFeature(ResolverFeature.CATALOG_FILES, Collections.singletonList(catalog2));
             CatalogManager umanager = new CatalogManager(uconfig);
     
             Uri result = umanager.LookupPublic(null, "-//Sample Delegated//DTD Sample 3.0//EN");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample30/fail.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample30/fail.dtd")));
     
             result = umanager.LookupPublic("https://example.com/delegated/sample/3.0/sample.dtd", null);
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample30/fail.dtd"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample30/fail.dtd")));
         }
         */
 
         // ============================================================
 
         [Test]
-        public void lookupUri() {
+        public void LookupUri() {
             Uri result = manager.LookupUri("https://xmlresolver.org/ns/sample/sample.rng");
-            Assert.AreEqual(UriUtils.Resolve(UriUtils.Resolve(UriUtils.Cwd(), catalog1), "sample/sample.rng"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(UriUtils.Resolve(UriUtils.Cwd(), catalog1), "sample/sample.rng")));
         }
 
         [Test]
-        public void rewriteUri() {
+        public void RewriteUri() {
             Uri result = manager.LookupUri("https://example.com/path1/sample/sample.rng");
             Uri expected = new Uri("https://example.com/path2/sample/sample.rng");
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         [Test]
-        public void uriSuffix() {
+        public void UriSuffix() {
             Uri result = manager.LookupUri("https://example.com/whatever/you/want/suffix.rnc");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample20/sample-suffix.rnc"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample20/sample-suffix.rnc")));
         }
 
         [Test]
-        public void delegateUriLong() {
+        public void DelegateUriLong() {
             Uri result = manager.LookupUri("https://example.com/delegated/sample/1.0/sample.rng");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample10/sample-delegated.rng"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample10/sample-delegated.rng")));
         }
 
         [Test]
-        public void delegateUriShort() {
+        public void DelegateUriShort() {
             Uri result = manager.LookupUri("https://example.com/delegated/sample/2.0/sample.rng");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample20/sample-shorter.rng"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample20/sample-shorter.rng")));
         }
 
         [Test]
-        public void delegateUriFail() {
+        public void DelegateUriFail() {
             Uri result = manager.LookupUri("https://example.com/delegated/sample/3.0/sample.rng");
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void undelegatedUri() {
+        public void UndelegatedUri() {
             // If there aren't any delegate entries, the entries in lookup2.xml really do match.
             XmlResolverConfiguration uconfig = new XmlResolverConfiguration(new(), new());
             List<string> cats = new();
@@ -298,40 +292,40 @@ namespace UnitTests {
             CatalogManager umanager = (CatalogManager) uconfig.GetFeature(ResolverFeature.CATALOG_MANAGER);
     
             Uri result = umanager.LookupUri("https://example.com/delegated/sample/3.0/sample.rng");
-            Assert.AreEqual(UriUtils.Resolve(catalog1, "sample30/fail.rng"), result);
+            Assert.That(result, Is.EqualTo(UriUtils.Resolve(catalog1, "sample30/fail.rng")));
         }
     
         [Test]
-        public void baseUriRootTest() {
+        public void BaseUriRootTest() {
             // Make sure an xml:base attribute on the root element works
             List<String> catalog = new();
             catalog.Add(UriUtils.Resolve(catalog1, "lookup-test.xml").ToString());
             XmlResolverConfiguration config = new XmlResolverConfiguration(new(), catalog);
             CatalogManager manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             Uri result = manager.LookupPublic("https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd", "-//W3C//DTD SVG 1.1//EN");
-            Assert.AreEqual("/usr/local/DTDs/svg11/system-svg11.dtd", result.AbsolutePath);
+            Assert.That(result.AbsolutePath, Is.EqualTo("/usr/local/DTDs/svg11/system-svg11.dtd"));
         }
     
         [Test]
-        public void baseUriGroupTest() {
+        public void BaseUriGroupTest() {
             // Make sure an xml:base attribute on a group element works
             List<String> catalog = new();
             catalog.Add(UriUtils.Resolve(catalog1, "lookup-test.xml").ToString());
             XmlResolverConfiguration config = new XmlResolverConfiguration(new(), catalog);
             CatalogManager manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             Uri result = manager.LookupPublic("https://www.w3.org/Graphics/SVG/1.1/DTD/svg11-basic.dtd", "-//W3C//DTD SVG 1.1 Basic//EN");
-            Assert.AreEqual("/usr/local/nested/DTDs/svg11/system-svg11-basic.dtd", result.AbsolutePath);
+            Assert.That(result.AbsolutePath, Is.EqualTo("/usr/local/nested/DTDs/svg11/system-svg11-basic.dtd"));
         }
     
         [Test]
-        public void baseUriOnElementTest() {
+        public void BaseUriOnElementTest() {
             // Make sure an xml:base attribute on the actual element works
             List<String> catalog = new();
             catalog.Add(UriUtils.Resolve(catalog1, "lookup-test.xml").ToString());
             XmlResolverConfiguration config = new XmlResolverConfiguration(new(), catalog);
             CatalogManager manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             Uri result = manager.LookupSystem("https://example.com/test.dtd");
-            Assert.AreEqual("/usr/local/on/DTDs/test.dtd", result.AbsolutePath);
+            Assert.That(result.AbsolutePath, Is.EqualTo("/usr/local/on/DTDs/test.dtd"));
         }
     }
 }

--- a/XmlResolver/UnitTests/CatalogResolverTest.cs
+++ b/XmlResolver/UnitTests/CatalogResolverTest.cs
@@ -31,7 +31,7 @@ namespace UnitTests {
                 CatalogManager manager =
                     (CatalogManager) resolver.GetConfiguration().GetFeature(ResolverFeature.CATALOG_MANAGER);
                 Uri rsrc = manager.LookupSystem("https://xmlresolver.org/ns/sample-as-uri/sample.dtd");
-                Assert.Null(rsrc);
+                Assert.That(rsrc, Is.Null);
             }
             catch (Exception) {
                 Assert.Fail();
@@ -44,7 +44,7 @@ namespace UnitTests {
             try {
                 object stream = resolver.GetEntity(new Uri("https://xmlresolver.org/ns/sample-as-uri/sample.dtd"),
                     null, null);
-                Assert.NotNull(stream);
+                Assert.That(stream, Is.Not.Null);
             }
             catch (Exception ex) {
                 Console.WriteLine(ex.Message);

--- a/XmlResolver/UnitTests/DataAssemblyTest.cs
+++ b/XmlResolver/UnitTests/DataAssemblyTest.cs
@@ -29,9 +29,9 @@ namespace UnitTests {
         public void LookupRddl() {
             var res = resolver.CatalogResolver.ResolveEntity(null, null,
                 "http://www.rddl.org/rddl-resource-1.mod", null);
-            Assert.NotNull(res);
-            Assert.NotNull(res.GetInputStream());
-            Assert.NotNull(res.GetLocalUri());
+            Assert.That(res, Is.Not.Null);
+            Assert.That(res.GetInputStream(), Is.Not.Null);
+            Assert.That(res.GetLocalUri(), Is.Not.Null);
             Assert.That(res.GetLocalUri().Scheme == "pack");
         }
         
@@ -40,7 +40,7 @@ namespace UnitTests {
             config.SetFeature(ResolverFeature.USE_DATA_ASSEMBLY, false);
             var res = resolver.CatalogResolver.ResolveEntity(null, null,
                 "http://www.rddl.org/rddl-resource-1.mod", null);
-            Assert.IsNull(res);
+            Assert.That(res, Is.Null);
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace UnitTests {
                 "http://www.rddl.org/rddl-resource-1.mod", null);
             
             // With the cache and the data assembly disabled, we won't return anything
-            Assert.Null(res);
+            Assert.That(res, Is.Null);
         }
 
         [Test]
@@ -77,9 +77,9 @@ namespace UnitTests {
         [Test]
         public void lookupCheckUri() {
             var res = resolver.CatalogResolver.ResolveUri("https://xmlresolver.org/data/resolver/succeeded/test/check.xml", null);
-            Assert.NotNull(res);
-            Assert.NotNull(res.GetInputStream());
-            Assert.NotNull(res.GetLocalUri());
+            Assert.That(res, Is.Not.Null);
+            Assert.That(res.GetInputStream(), Is.Not.Null);
+            Assert.That(res.GetLocalUri(), Is.Not.Null);
             Assert.That(res.GetLocalUri().Scheme == "pack");
         }
     }

--- a/XmlResolver/UnitTests/DataUriTest.cs
+++ b/XmlResolver/UnitTests/DataUriTest.cs
@@ -15,7 +15,7 @@ namespace UnitTests {
         }
         
         [Test]
-        public void testDataUritext() {
+        public void TestDataUritext() {
             string href = "example.txt";
             string baseuri = "http://example.com/";
 
@@ -24,11 +24,11 @@ namespace UnitTests {
             using (StreamReader reader = new StreamReader(result.GetInputStream())) {
                 line = reader.ReadLine();
             }
-            Assert.AreEqual("A short note.", line);
+            Assert.That(line, Is.EqualTo("A short note."));
         }
         
         [Test]
-        public void testDataUricharset() {
+        public void TestDataUricharset() {
             string href = "greek.txt";
             string baseuri = "http://example.com/";
 
@@ -41,11 +41,11 @@ namespace UnitTests {
             using (StreamReader reader = new StreamReader(result.GetInputStream())) {
                 line = reader.ReadLine();
             }
-            Assert.AreEqual("ΎχΎ", line);
+            Assert.That(line, Is.EqualTo("ΎχΎ"));
         }
         
         [Test]
-        public void testDataUriencoded() {
+        public void TestDataUriencoded() {
             string href = "example.xml";
             string baseuri = "http://example.com/";
 
@@ -54,7 +54,7 @@ namespace UnitTests {
             using (StreamReader reader = new StreamReader(result.GetInputStream())) {
                 line = reader.ReadLine();
             }
-            Assert.AreEqual("<doc>I was a data URI</doc>", line);
+            Assert.That(line, Is.EqualTo("<doc>I was a data URI</doc>"));
         }
     }
 }

--- a/XmlResolver/UnitTests/FeatureTest.cs
+++ b/XmlResolver/UnitTests/FeatureTest.cs
@@ -17,76 +17,76 @@ namespace UnitTests {
         private void BooleanFeature(BoolResolverFeature feature) {
             bool orig = (bool) config.GetFeature(feature);
             config.SetFeature(feature, false);
-            Assert.AreEqual(false, config.GetFeature(feature));
+            Assert.That(config.GetFeature(feature), Is.EqualTo(false));
             config.SetFeature(feature, true);
-            Assert.AreEqual(true, config.GetFeature(feature));
+            Assert.That(config.GetFeature(feature), Is.EqualTo(true));
             config.SetFeature(feature, orig);
         }
 
         private void StringFeature(StringResolverFeature feature) {
             string orig = (string) config.GetFeature(feature);
             config.SetFeature(feature, "apple pie");
-            Assert.AreEqual("apple pie", config.GetFeature(feature));
+            Assert.That(config.GetFeature(feature), Is.EqualTo("apple pie"));
             config.SetFeature(feature, orig);
         }
 
         [Test]
         public void TestAllowCatalogPi() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.ALLOW_CATALOG_PI));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.ALLOW_CATALOG_PI), Is.EqualTo(true));
             BooleanFeature(ResolverFeature.ALLOW_CATALOG_PI);
         }
         
         [Test]
         public void TestArchivedCatalogs() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.ARCHIVED_CATALOGS));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.ARCHIVED_CATALOGS), Is.EqualTo(true));
             BooleanFeature(ResolverFeature.ARCHIVED_CATALOGS);
         }
 
         [Test]
         public void TestCacheUnderHome() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.CACHE_UNDER_HOME));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.CACHE_UNDER_HOME), Is.EqualTo(true));
             BooleanFeature(ResolverFeature.CACHE_UNDER_HOME);
         }
 
         [Test]
         public void TestMaskPackUris() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.MASK_PACK_URIS));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.MASK_PACK_URIS), Is.EqualTo(true));
             BooleanFeature(ResolverFeature.MASK_PACK_URIS);
         }
 
         [Test]
         public void TestMergeHttps() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.MERGE_HTTPS));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.MERGE_HTTPS), Is.EqualTo(true));
             BooleanFeature(ResolverFeature.MERGE_HTTPS);
         }
 
         [Test]
         public void TestParseRddl() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.PARSE_RDDL));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.PARSE_RDDL), Is.EqualTo(true));
             BooleanFeature(ResolverFeature.PARSE_RDDL);
         }
 
         [Test]
         public void TestPreferPropertyFile() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.PREFER_PROPERTY_FILE));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.PREFER_PROPERTY_FILE), Is.EqualTo(true));
             BooleanFeature(ResolverFeature.PREFER_PROPERTY_FILE);
         }
 
         [Test]
         public void TestPreferPublic() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.PREFER_PUBLIC));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.PREFER_PUBLIC), Is.EqualTo(true));
             BooleanFeature(ResolverFeature.PREFER_PUBLIC);
         }
 
         [Test]
         public void TestUriForSystem() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.URI_FOR_SYSTEM));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.URI_FOR_SYSTEM), Is.EqualTo(true));
             BooleanFeature(ResolverFeature.URI_FOR_SYSTEM);
         }
 
         [Test]
         public void TestAssemblyCatalog() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.ASSEMBLY_CATALOGS));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.ASSEMBLY_CATALOGS), Is.EqualTo(true));
             
             List<string> orig = (List<string>)config.GetFeature(ResolverFeature.ASSEMBLY_CATALOGS);
             
@@ -113,29 +113,29 @@ namespace UnitTests {
 
         [Test]
         public void TestCacheDirectory() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.CACHE_DIRECTORY));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.CACHE_DIRECTORY), Is.EqualTo(true));
             StringFeature(ResolverFeature.CACHE_DIRECTORY);
         }
 
         [Test]
         public void TestCatalogLoaderClass() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.CATALOG_LOADER_CLASS));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.CATALOG_LOADER_CLASS), Is.EqualTo(true));
             StringFeature(ResolverFeature.CATALOG_LOADER_CLASS);
         }
 
         private void sameLists(List<string> list1, List<string> list2) {
             // Hack
             foreach (var cur in list1) {
-                Assert.True(list2.Contains(cur));
+                Assert.That(list2.Contains(cur), Is.EqualTo(true));
             }
             foreach (var cur in list2) {
-                Assert.True(list1.Contains(cur));
+                Assert.That(list1.Contains(cur), Is.EqualTo(true));
             }
         }
 
         [Test]
         public void TestFeatureCatalogFiles() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.CATALOG_FILES));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.CATALOG_FILES), Is.EqualTo(true));
 
             List<string> orig = (List<string>)config.GetFeature(ResolverFeature.CATALOG_FILES);
             List<string> myList = new List<string> { "One", "Two", "Three" };
@@ -150,7 +150,7 @@ namespace UnitTests {
 
             // None of "mine" survived
             foreach (var cur in myList) {
-                Assert.False(current.Contains(cur));
+                Assert.That(current.Contains(cur), Is.EqualTo(false));
             }
             
             sameLists(current, newList);
@@ -160,7 +160,7 @@ namespace UnitTests {
         
         [Test]
         public void TestFeatureCatalogAdditions() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.CATALOG_ADDITIONS));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.CATALOG_ADDITIONS), Is.EqualTo(true));
 
             List<string> origCatalogs = (List<string>)config.GetFeature(ResolverFeature.CATALOG_FILES);
             List<string> origAdditions = (List<string>)config.GetFeature(ResolverFeature.CATALOG_ADDITIONS);
@@ -176,10 +176,10 @@ namespace UnitTests {
             current = (List<string>)config.GetFeature(ResolverFeature.CATALOG_FILES);
 
             foreach (var mine in myCatalogs) {
-                Assert.True(current.Contains(mine));
+                Assert.That(current.Contains(mine), Is.EqualTo(true));
             }
             foreach (var mine in myList) {
-                Assert.True(current.Contains(mine));
+                Assert.That(current.Contains(mine), Is.EqualTo(true));
             }
 
             config.SetFeature(ResolverFeature.CATALOG_FILES, origCatalogs);
@@ -188,21 +188,21 @@ namespace UnitTests {
 
         [Test]
         public void TestFeatureCatalogManager() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.CATALOG_MANAGER));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.CATALOG_MANAGER), Is.EqualTo(true));
             CatalogManager manager = new CatalogManager(config);
             CatalogManager orig = (CatalogManager)config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             config.SetFeature(ResolverFeature.CATALOG_MANAGER, manager);
-            Assert.AreSame(manager, config.GetFeature(ResolverFeature.CATALOG_MANAGER));
+            Assert.That(manager, Is.SameAs(config.GetFeature(ResolverFeature.CATALOG_MANAGER)));
             config.SetFeature(ResolverFeature.CATALOG_MANAGER, orig);
         }
 
         [Test]
         public void TestFeatureCache() {
-            Assert.True(config.GetFeatures().Contains(ResolverFeature.CACHE));
+            Assert.That(config.GetFeatures().Contains(ResolverFeature.CACHE), Is.EqualTo(true));
             ResourceCache myCache = new ResourceCache(config);
             ResourceCache orig = (ResourceCache)config.GetFeature(ResolverFeature.CACHE);
             config.SetFeature(ResolverFeature.CACHE, myCache);
-            Assert.AreSame(myCache, config.GetFeature(ResolverFeature.CACHE));
+            Assert.That(myCache, Is.SameAs(config.GetFeature(ResolverFeature.CACHE)));
             config.SetFeature(ResolverFeature.CACHE, orig);
         }
     }

--- a/XmlResolver/UnitTests/InstantiationTest.cs
+++ b/XmlResolver/UnitTests/InstantiationTest.cs
@@ -8,7 +8,7 @@ namespace UnitTests {
         public void InstantiateTest() {
             var handle = Activator.CreateInstance("XmlResolver", "Org.XmlResolver.Resolver");
             Resolver resolver = (Resolver) handle.Unwrap();
-            Assert.NotNull(resolver);
+            Assert.That(resolver, Is.Not.Null);
         }
     }
 }

--- a/XmlResolver/UnitTests/LoaderTest.cs
+++ b/XmlResolver/UnitTests/LoaderTest.cs
@@ -13,7 +13,7 @@ namespace UnitTests {
             config.AddAssemblyCatalog("resources/catalog.xml", Assembly.GetExecutingAssembly());
             CatalogManager manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             Uri rsrc = manager.LookupSystem("https://xmlresolver.org/ns/sample/sample.dtd");
-            Assert.NotNull(rsrc);
+            Assert.That(rsrc, Is.Not.Null);
         }
 
         [Test]
@@ -22,7 +22,7 @@ namespace UnitTests {
             config.AddAssemblyCatalog("resources/invalid-catalog.xml", Assembly.GetExecutingAssembly());
             CatalogManager manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             Uri rsrc = manager.LookupSystem("https://xmlresolver.org/ns/sample/sample.dtd");
-            Assert.NotNull(rsrc);
+            Assert.That(rsrc, Is.Not.Null);
         }
 
         [Test]
@@ -31,7 +31,7 @@ namespace UnitTests {
             config.AddAssemblyCatalog("resources/catalog.xml", Assembly.GetExecutingAssembly());
             CatalogManager manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             Uri rsrc = manager.LookupSystem("https://xmlresolver.org/ns/sample/sample.dtd");
-            Assert.NotNull(rsrc);
+            Assert.That(rsrc, Is.Not.Null);
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace UnitTests {
             config.SetFeature(ResolverFeature.CATALOG_LOADER_CLASS, "Org.XmlResolver.Loaders.ValidatingXmlLoader");
             CatalogManager manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             Uri rsrc = manager.LookupSystem("https://xmlresolver.org/ns/sample/sample.dtd");
-            Assert.NotNull(rsrc);
+            Assert.That(rsrc, Is.Not.Null);
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace UnitTests {
             config.SetFeature(ResolverFeature.CATALOG_LOADER_CLASS, "Org.XmlResolver.Loaders.ValidatingXmlLoader");
             CatalogManager manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             Uri rsrc = manager.LookupSystem("https://xmlresolver.org/ns/sample/sample.dtd");
-            Assert.NotNull(rsrc);
+            Assert.That(rsrc, Is.Not.Null);
         }
 
         //FIXME: [Test]
@@ -63,7 +63,7 @@ namespace UnitTests {
             CatalogManager manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             try {
                 Uri rsrc = manager.LookupSystem("https://xmlresolver.org/ns/sample/sample.dtd");
-                Assert.NotNull(rsrc);
+                Assert.That(rsrc, Is.Not.Null);
                 Assert.Fail();
             }
             catch (Exception) {
@@ -80,7 +80,7 @@ namespace UnitTests {
             CatalogManager manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             try {
                 Uri rsrc = manager.LookupSystem("https://xmlresolver.org/ns/sample/sample.dtd");
-                Assert.NotNull(rsrc);
+                Assert.That(rsrc, Is.Not.Null);
             }
             catch (Exception) {
                 Assert.Fail();

--- a/XmlResolver/UnitTests/MergeHttpsTests.cs
+++ b/XmlResolver/UnitTests/MergeHttpsTests.cs
@@ -48,98 +48,99 @@ namespace UnitTests {
 
         [Test]
         public void Equivalentcp1() {
-            Assert.AreEqual("classpath:path/to/thing",
-                noMergeManager.NormalizedForComparison("classpath:/path/to/thing"));
+            Assert.That(noMergeManager.NormalizedForComparison("classpath:/path/to/thing"),
+                        Is.EqualTo("classpath:path/to/thing"));
+                
         }
 
         [Test]
         public void Equivalentcp2() {
-            Assert.AreEqual("classpath:path/to/thing",
-                noMergeManager.NormalizedForComparison("classpath:path/to/thing"));
+            Assert.That(noMergeManager.NormalizedForComparison("classpath:path/to/thing"),
+                        Is.EqualTo("classpath:path/to/thing"));
         }
 
         [Test]
         public void Equivalentcp1m() {
-            Assert.AreEqual("classpath:path/to/thing",
-                mergeManager.NormalizedForComparison("classpath:/path/to/thing"));
+            Assert.That(mergeManager.NormalizedForComparison("classpath:/path/to/thing"),
+                        Is.EqualTo("classpath:path/to/thing"));
         }
 
         [Test]
         public void Equivalentcp2m() {
-            Assert.AreEqual("classpath:path/to/thing", mergeManager.NormalizedForComparison("classpath:path/to/thing"));
+            Assert.That(mergeManager.NormalizedForComparison("classpath:path/to/thing"), Is.EqualTo("classpath:path/to/thing"));
         }
 
         [Test]
         public void Equivalenthttp1() {
-            Assert.AreEqual("https://localhost/path/to/thing",
-                noMergeManager.NormalizedForComparison("https://localhost/path/to/thing"));
+            Assert.That(noMergeManager.NormalizedForComparison("https://localhost/path/to/thing"),
+                        Is.EqualTo("https://localhost/path/to/thing"));
         }
 
         [Test]
         public void Equivalenthttp2() {
-            Assert.AreEqual("http://localhost/path/to/thing",
-                noMergeManager.NormalizedForComparison("http://localhost/path/to/thing"));
+            Assert.That(noMergeManager.NormalizedForComparison("http://localhost/path/to/thing"),
+                        Is.EqualTo("http://localhost/path/to/thing"));
         }
 
         [Test]
         public void Equivalenthttp3() {
-            Assert.AreEqual("ftp://localhost/path/to/thing",
-                noMergeManager.NormalizedForComparison("ftp://localhost/path/to/thing"));
+            Assert.That(noMergeManager.NormalizedForComparison("ftp://localhost/path/to/thing"),
+                        Is.EqualTo("ftp://localhost/path/to/thing"));
         }
 
         [Test]
         public void Equivalenthttp1m() {
-            Assert.AreEqual("https://localhost/path/to/thing",
-                mergeManager.NormalizedForComparison("https://localhost/path/to/thing"));
+            Assert.That(mergeManager.NormalizedForComparison("https://localhost/path/to/thing"),
+                        Is.EqualTo("https://localhost/path/to/thing"));
         }
 
         [Test]
         public void Equivalenthttp2m() {
-            Assert.AreEqual("https://localhost/path/to/thing",
-                mergeManager.NormalizedForComparison("http://localhost/path/to/thing"));
+            Assert.That(mergeManager.NormalizedForComparison("http://localhost/path/to/thing"),
+                        Is.EqualTo("https://localhost/path/to/thing"));
         }
 
         [Test]
         public void Equivalenthttp3m() {
-            Assert.AreEqual("ftp://localhost/path/to/thing",
-                mergeManager.NormalizedForComparison("ftp://localhost/path/to/thing"));
+            Assert.That(mergeManager.NormalizedForComparison("ftp://localhost/path/to/thing"),
+                        Is.EqualTo("ftp://localhost/path/to/thing"));
         }
 
 
         [Test]
         public void LookupHttpUri() {
             Uri result = mergeManager.LookupUri("http://www.w3.org/2001/xml.xsd");
-            Assert.NotNull(result);
+            Assert.That(result, Is.Not.Null);
         }
 
         [Test]
         public void LookupHttpSystem() {
             Uri result = mergeManager.LookupSystem("http://www.w3.org/MarkUp/DTD/xhtml-basic11.dtd");
-            Assert.NotNull(result);
+            Assert.That(result, Is.Not.Null);
         }
 
         [Test]
         public void LookupHttpsSystem() {
             Uri result = mergeManager.LookupSystem("https://www.rddl.org/rddl-xhtml.dtd");
-            Assert.NotNull(result);
+            Assert.That(result, Is.Not.Null);
         }
 
         [Test]
         public void LookupHttpUriNoMerge() {
             Uri result = noMergeManager.LookupUri("http://www.w3.org/2001/xml.xsd");
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
         public void LookupHttpSystemNoMerge() {
             Uri result = noMergeManager.LookupSystem("http://www.w3.org/MarkUp/DTD/xhtml-basic11.dtd");
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
         public void LookupHttpsSystemNoMerge() {
             Uri result = noMergeManager.LookupSystem("https://www.rddl.org/rddl-xhtml.dtd");
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/XmlResolver/UnitTests/NamespaceTest.cs
+++ b/XmlResolver/UnitTests/NamespaceTest.cs
@@ -22,39 +22,39 @@ namespace UnitTests {
         }
 
         [Test]
-        public void lookupOneForValidation() {
+        public void LookupOneForValidation() {
             Uri result = manager.LookupNamespaceUri("http://example.com/one", "the-one-nature", "validation");
             Assert.That(result.ToString().EndsWith("/resources/one-validate.xml"));
         }
 
         [Test]
-        public void lookupOneForSomethingElse() {
+        public void LookupOneForSomethingElse() {
             Uri result = manager.LookupNamespaceUri("http://example.com/one", "the-one-nature", "somethingelse");
             Assert.That(result.ToString().EndsWith("/resources/one-else.xml"));
         }
 
         [Test]
-        public void lookupTwoForValidation() {
+        public void LookupTwoForValidation() {
             Uri result = manager.LookupNamespaceUri("http://example.com/two", "the-two-nature", "validation");
             Assert.That(result.ToString().EndsWith("/resources/two-validate.xml"));
         }
 
         [Test]
-        public void lookupTwoForAnythingElse() {
+        public void LookupTwoForAnythingElse() {
             Uri result = manager.LookupNamespaceUri("http://example.com/two", "the-two-nature", "anything-else");
             Assert.That(result.ToString().EndsWith("/resources/two-anything-else.xml"));
         }
         
         [Test]
-        public void resolveWithHref() {
+        public void ResolveWithHref() {
             object stream = resolver.GetEntity("one", new Uri("http://example.com/"), "the-one-nature", "validation");
-            Assert.NotNull(stream);
+            Assert.That(stream, Is.Not.Null);
         }
 
         [Test]
-        public void resolveWithURI() {
+        public void ResolveWithURI() {
             object stream = resolver.GetEntity(new Uri("http://example.com/one"), "the-one-nature", "validation");
-            Assert.NotNull(stream);
+            Assert.That(stream, Is.Not.Null);
         }
     }
 }

--- a/XmlResolver/UnitTests/PropertyFileTest.cs
+++ b/XmlResolver/UnitTests/PropertyFileTest.cs
@@ -21,8 +21,8 @@ namespace UnitTests {
                 f1 = f1 || cat.EndsWith(s1);
                 f2 = f2 || cat.EndsWith(s2);
             }
-            Assert.True(f1);
-            Assert.True(f2);
+            Assert.That(f1, Is.EqualTo(true));
+            Assert.That(f2, Is.EqualTo(true));
         }
         
         [Test]
@@ -39,8 +39,8 @@ namespace UnitTests {
                 f1 = f1 || cat.Equals(s1);
                 f2 = f2 || cat.Equals(s2);
             }
-            Assert.True(f1);
-            Assert.True(f2);
+            Assert.That(f1, Is.EqualTo(true));
+            Assert.That(f2, Is.EqualTo(true));
         }
     }
 }

--- a/XmlResolver/UnitTests/ResolverTest.cs
+++ b/XmlResolver/UnitTests/ResolverTest.cs
@@ -27,7 +27,7 @@ namespace UnitTests {
 
                 ResolvedResource rsrc = cresolver.ResolveEntity(null, null, "https://example.com/not/in/catalog", null);
 
-                Assert.Null(rsrc);
+                Assert.That(rsrc, Is.Null);
             } catch (Exception) {
                 Assert.Fail();
             }
@@ -40,7 +40,7 @@ namespace UnitTests {
 
                 ResolvedResource rsrc = cresolver.ResolveEntity(null, null, "file:///path/to/thing/that/isnt/likely/to/exist", null);
 
-                Assert.Null(rsrc);
+                Assert.That(rsrc, Is.Null);
             } catch (Exception ex)
             {
                 Console.WriteLine(ex.Message);
@@ -56,8 +56,8 @@ namespace UnitTests {
 
                 ResolvedResource rsrc = cresolver.ResolveEntity(null, null, "https://example.com/sample/1.0/sample.dtd", null);
 
-                Assert.NotNull(rsrc.GetInputStream());
-                Assert.AreEqual(result, rsrc.GetLocalUri());
+                Assert.That(rsrc.GetInputStream(), Is.Not.Null);
+                Assert.That(rsrc.GetLocalUri(), Is.EqualTo(result));
             } catch (Exception ex) {
                 Console.WriteLine(ex.Message);
                 Assert.Fail();
@@ -72,8 +72,8 @@ namespace UnitTests {
 
                 ResolvedResource rsrc = cresolver.ResolveEntity(null, null, "https://example.com/sample/1.0/uri.dtd", null);
 
-                Assert.NotNull(rsrc.GetInputStream());
-                Assert.AreEqual(result, rsrc.GetLocalUri());
+                Assert.That(rsrc.GetInputStream(), Is.Not.Null);
+                Assert.That(rsrc.GetLocalUri(), Is.EqualTo(result));
             } catch (Exception) {
                 Assert.Fail();
             }
@@ -94,7 +94,7 @@ namespace UnitTests {
 
                 ResolvedResource rsrc = cresolver.ResolveEntity(null, null, "https://xmlresolver.org/ns/sample-as-uri/sample.dtd", null);
 
-                Assert.NotNull(rsrc.GetInputStream());
+                Assert.That(rsrc.GetInputStream(), Is.Not.Null);
             } catch (Exception) {
                 Assert.Fail();
             }

--- a/XmlResolver/UnitTests/ResolverTestJar.cs
+++ b/XmlResolver/UnitTests/ResolverTestJar.cs
@@ -27,7 +27,7 @@ namespace UnitTests {
 
             try {
                 object stream = resolver.GetEntity(UriUtils.NewUri(systemId), null, typeof(Stream));
-                Assert.NotNull(stream);
+                Assert.That(stream, Is.Not.Null);
             } catch (Exception) {
                 Assert.Fail();
             }

--- a/XmlResolver/UnitTests/UnitTests.csproj
+++ b/XmlResolver/UnitTests/UnitTests.csproj
@@ -1,17 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-        <PackageReference Include="NuGet.Frameworks" Version="5.10.0" />
-        <PackageReference Include="NUnit" Version="3.13.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageReference Include="coverlet.collector" Version="3.0.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+        <PackageReference Include="NUnit" Version="4.2.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
+        <PackageReference Include="XmlResolverData" Version="1.2.4" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.2" />
 
         <!-- Data -->
 
@@ -261,10 +267,6 @@
         <EmbeddedResource Include="resources/lookup-shorter.xml">
           <LogicalName>resources.lookup-shorter.xml</LogicalName>
         </EmbeddedResource>
-
-        <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
-
-        <PackageReference Include="XmlResolverData" Version="1.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/XmlResolver/UnitTests/ZipCatalogTest.cs
+++ b/XmlResolver/UnitTests/ZipCatalogTest.cs
@@ -26,8 +26,8 @@ namespace UnitTests {
             var manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
 
             Uri result = manager.LookupSystem("https://xmlresolver.org/ns/zipped/blocks.dtd");
-            Assert.True(result.ToString().StartsWith("pack://file%3"));
-            Assert.True(result.ToString().EndsWith(",sample.zip/sample.dtd"));
+            Assert.That(result.ToString().StartsWith("pack://file%3"), Is.EqualTo(true));
+            Assert.That(result.ToString().EndsWith(",sample.zip/sample.dtd"), Is.EqualTo(true));
         }
 
         [Test]
@@ -37,8 +37,8 @@ namespace UnitTests {
             var manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
             
             Uri result = manager.LookupUri("https://xmlresolver.org/ns/zipped/sample.rnc");
-            Assert.True(result.ToString().StartsWith("pack://file%3"));
-            Assert.True(result.ToString().EndsWith(",dir-sample.zip/directory-x.y/sample.rnc"));
+            Assert.That(result.ToString().StartsWith("pack://file%3"), Is.EqualTo(true));
+            Assert.That(result.ToString().EndsWith(",dir-sample.zip/directory-x.y/sample.rnc"), Is.EqualTo(true));
         }
         [Test]
         public void lookupZip3Uri() {
@@ -47,8 +47,8 @@ namespace UnitTests {
             var manager = (CatalogManager) config.GetFeature(ResolverFeature.CATALOG_MANAGER);
 
             Uri result = manager.LookupUri("https://xmlresolver.org/ns/zipped/blocks.rnc");
-            Assert.True(result.ToString().StartsWith("pack://file%3"));
-            Assert.True(result.ToString().EndsWith(",sample-org.zip/schemas/blocks.rnc"));
+            Assert.That(result.ToString().StartsWith("pack://file%3"), Is.EqualTo(true));
+            Assert.That(result.ToString().EndsWith(",sample-org.zip/schemas/blocks.rnc"), Is.EqualTo(true));
         }
     }
 }

--- a/XmlResolver/XmlResolver.sln.DotSettings.user
+++ b/XmlResolver/XmlResolver.sln.DotSettings.user
@@ -1,10 +1,24 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=a595a3dd_002Ddd5c_002D4b60_002D85a0_002D82d8931f9dd8/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from &amp;lt;UnitTests&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=7020124F_002D9FFC_002D4AC3_002D8F3D_002DAAB8E0240759_002Ff_003AAssert_002Ecs_002Fl_003A_002E_002E_003F_002E_002E_003F_002E_002E_003F_002E_002E_003F_002E_002E_003FUsers_003Fndw_003FLibrary_003FApplication_0020Support_003FJetBrains_003FRider2024_002E3_003Fresharper_002Dhost_003FSourcesCache_003F98514e314f1feddb3082dbe8507ecec1a81b6491c0db7dc53c2e8c13949e4360_003FAssert_002Ecs/@EntryIndexedValue">ForceIncluded</s:String>
+	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=7020124F_002D9FFC_002D4AC3_002D8F3D_002DAAB8E0240759_002Ff_003AExceptionDispatchInfo_002Ecs_002Fl_003A_002E_002E_003F_002E_002E_003F_002E_002E_003F_002E_002E_003F_002E_002E_003FUsers_003Fndw_003FLibrary_003FApplication_0020Support_003FJetBrains_003FRider2024_002E3_003Fresharper_002Dhost_003FSourcesCache_003Fbf9021a960b74107a7e141aa06bc9d8a0a53c929178c2fb95b1597be8af8dc_003FExceptionDispatchInfo_002Ecs/@EntryIndexedValue">ForceIncluded</s:String>
+	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=7020124F_002D9FFC_002D4AC3_002D8F3D_002DAAB8E0240759_002Ff_003AXmlResolver_002Ecs_002Fl_003A_002E_002E_003F_002E_002E_003F_002E_002E_003F_002E_002E_003F_002E_002E_003FUsers_003Fndw_003FLibrary_003FApplication_0020Support_003FJetBrains_003FRider2024_002E3_003Fresharper_002Dhost_003FSourcesCache_003Fb627cde2363f4cdf4ba8b7747cc8a59a8685dfc352255f527b5f3fc7b1d76d9_003FXmlResolver_002Ecs/@EntryIndexedValue">ForceIncluded</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=4e163d65_002D1663_002D49bf_002Da333_002D99b4500b0afe/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Session" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
   &lt;Or&gt;
     &lt;Project Location="/Volumes/Projects/xmlresolver/cs/XmlResolver/UnitTests" Presentation="&amp;lt;UnitTests&amp;gt;" /&gt;
     &lt;TestAncestor&gt;
       &lt;TestId&gt;NUnit3x::BB285ECA-8684-49AF-9A25-4B80E64B307C::net6.0::TestCS.Tests&lt;/TestId&gt;
     &lt;/TestAncestor&gt;
   &lt;/Or&gt;
+&lt;/SessionState&gt;</s:String>
+	
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=a595a3dd_002Ddd5c_002D4b60_002D85a0_002D82d8931f9dd8/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="All tests from &amp;lt;UnitTests&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+  &lt;Or&gt;
+    &lt;Project Location="/Volumes/Projects/xmlresolver/cs/XmlResolver/UnitTests" Presentation="&amp;lt;UnitTests&amp;gt;" /&gt;
+    &lt;TestAncestor&gt;
+      &lt;TestId&gt;NUnit3x::BB285ECA-8684-49AF-9A25-4B80E64B307C::net6.0::TestCS.Tests&lt;/TestId&gt;
+    &lt;/TestAncestor&gt;
+  &lt;/Or&gt;
+&lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=b9eeab04_002Dcbf2_002D48d1_002Db031_002D4566f4429e2f/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+  &lt;Solution /&gt;
 &lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/XmlResolver/XmlResolver/Org/XmlResolver/XmlResolverConfiguration.cs
+++ b/XmlResolver/XmlResolver/Org/XmlResolver/XmlResolverConfiguration.cs
@@ -244,17 +244,20 @@ namespace Org.XmlResolver {
                             loaded = pfile;
                             section = config.GetSection("xmlResolver");
                         }
-                        catch (XmlException) {
-                            // Maybe it's a JSON file?
-                            cfgBuilder = new ConfigurationBuilder();
-                            cfgBuilder.AddJsonFile(pfile.AbsolutePath);
-                            try {
-                                var config = cfgBuilder.Build();
-                                section = config.GetSection("XmlResolver");
-                                loaded = pfile;
-                            }
-                            catch (FormatException) {
-                                logger.Log(ResolverLogger.CONFIG, "Failed to read {0}", pfile.AbsolutePath);
+                        catch (Exception ex) {
+                            if (ex is XmlException || ex is InvalidDataException)
+                            {
+                                // Maybe it's a JSON file?
+                                cfgBuilder = new ConfigurationBuilder();
+                                cfgBuilder.AddJsonFile(pfile.AbsolutePath);
+                                try {
+                                    var config = cfgBuilder.Build();
+                                    section = config.GetSection("XmlResolver");
+                                    loaded = pfile;
+                                }
+                                catch (FormatException) {
+                                    logger.Log(ResolverLogger.CONFIG, "Failed to read {0}", pfile.AbsolutePath);
+                                }
                             }
                         }
                     }

--- a/XmlResolver/XmlResolver/XmlResolver.csproj
+++ b/XmlResolver/XmlResolver/XmlResolver.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Norman Walsh</Authors>
     <Description>The xmlresolver project provides an implementation of the System.Xml.XmlResolver. It uses the OASIS XML Catalogs V1.1 Standard to provide a mapping from external identifiers and URIs to local resources.</Description>
@@ -18,12 +18,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="5.0.0" />
-    <PackageReference Include="NLog" Version="4.7.10" />
-    <PackageReference Include="NuGet.Frameworks" Version="5.10.0" />
-    <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0" />
+    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-resolverVersion=2.1.0
+resolverVersion=2.1.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
1. Update library dependency versions
2. Remove unneeded dependency
3. Support .NET 6 and .NET 8
4. Fix exception handling for non-XML configurations